### PR TITLE
Fix runner metric persistence, improve log viewer UX, add journal per…

### DIFF
--- a/bin/fs-runner.sh
+++ b/bin/fs-runner.sh
@@ -107,6 +107,7 @@ echo
 # -----------------------------------------------------------------------------
 
 declare -A FAILURE_COUNTERS
+declare -A PREV_LAST_SUCCESS
 
 if [[ -f "$PROM_FILE" ]]; then
   while read -r line; do
@@ -114,6 +115,10 @@ if [[ -f "$PROM_FILE" ]]; then
       target=$(echo "$line" | sed -n 's/.*target="\([^"]*\)".*/\1/p')
       value=$(echo "$line" | awk '{print $NF}')
       FAILURE_COUNTERS["$target"]="$value"
+    elif [[ "$line" =~ fsbackup_snapshot_last_success ]]; then
+      target=$(echo "$line" | sed -n 's/.*target="\([^"]*\)".*/\1/p')
+      value=$(echo "$line" | awk '{print $NF}')
+      PREV_LAST_SUCCESS["$target"]="$value"
     fi
   done < "$PROM_FILE"
 fi
@@ -192,6 +197,7 @@ fsbackup_runner_target_last_exit_code{class="${CLASS}",target="${id}"} 0
 EOF
 
     FAILURE_COUNTERS["$id"]="${FAILURE_COUNTERS["$id"]:-0}"
+    log "$id" "Snapshot complete (exit 0)"
 
   else
     ((FAILED++))
@@ -202,6 +208,11 @@ fsbackup_snapshot_last_failure{class="${CLASS}",target="${id}"} ${NOW_EPOCH}
 fsbackup_runner_target_last_seen{class="${CLASS}",target="${id}"} ${NOW_EPOCH}
 fsbackup_runner_target_last_exit_code{class="${CLASS}",target="${id}"} ${rc}
 EOF
+    # Carry forward the previous last_success so Grafana retains the history
+    if [[ -n "${PREV_LAST_SUCCESS[$id]:-}" ]]; then
+      echo "fsbackup_snapshot_last_success{class=\"${CLASS}\",target=\"${id}\"} ${PREV_LAST_SUCCESS[$id]}" >>"$PROM_TMP"
+    fi
+    log "$id" "Snapshot FAILED (exit ${rc})"
   fi
 
   rm -f "$RSYNC_STATS_TMP"

--- a/web/README.md
+++ b/web/README.md
@@ -187,9 +187,10 @@ The script will:
 1. Ask which user will run the web UI
 2. Add that user to the `fsbackup` group (covers snapshot dirs and config files)
 3. Apply ACLs for paths not covered by the group (Prometheus textfile dir, AWS credentials)
-4. Generate a `web/.env` with a random `SECRET_KEY`, prompting for host/port and auth settings
-5. Create the Python venv and install dependencies
-6. Optionally write and enable a systemd unit
+4. Add that user to the `systemd-journal` group (needed for the log viewer on the Run page)
+5. Generate a `web/.env` with a random `SECRET_KEY`, prompting for host/port and auth settings
+6. Create the Python venv and install dependencies
+7. Optionally write and enable a systemd unit
 
 ## Permissions
 
@@ -203,6 +204,7 @@ this automatically. If you need to understand or redo it manually:
 | `/etc/fsbackup/` | read + traverse | `fsbackup` group |
 | `/var/lib/node_exporter/textfile_collector/` | read | ACL (set by setup.sh) |
 | `/var/lib/fsbackup/.aws/` | read | ACL (set by setup.sh) |
+| systemd journal | read | `systemd-journal` group (set by setup.sh) |
 
 The app sets `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` to point at
 `/var/lib/fsbackup/.aws/` at startup, so boto3 finds the `fsbackup` AWS profile

--- a/web/main.py
+++ b/web/main.py
@@ -598,19 +598,58 @@ async def api_browse(request: Request, path: str = ""):
     })
 
 
+_LOG_DIR = Path("/var/lib/fsbackup/log")
+
+# Map unit name prefixes to their log files (most specific first).
+_UNIT_LOG_MAP = [
+    ("fsbackup-runner@",       _LOG_DIR / "backup.log"),
+    ("fsbackup-promote",       _LOG_DIR / "backup.log"),
+    ("fsbackup-doctor@",       _LOG_DIR / "fs-orphans.log"),
+    ("fsbackup-mirror-daily",  _LOG_DIR / "mirror.log"),
+    ("fsbackup-mirror-retention", _LOG_DIR / "mirror-retention.log"),
+    ("fsbackup-s3-export",     _LOG_DIR / "s3-export.log"),
+]
+
+def _unit_log_file(unit: str) -> Path | None:
+    for prefix, path in _UNIT_LOG_MAP:
+        if unit.startswith(prefix):
+            return path
+    return None
+
+
 @app.get("/api/journal/{unit:path}", response_class=HTMLResponse)
-async def api_journal(request: Request, unit: str, n: int = 80):
-    """Return the last n lines of journalctl output for a unit."""
-    try:
-        r = subprocess.run(
-            ["journalctl", "-u", unit, "-n", str(n), "--no-pager",
-             "--output=short-iso", "--no-hostname"],
-            capture_output=True, text=True, timeout=8
-        )
-        lines = r.stdout.splitlines() if r.returncode == 0 else []
-        error = r.stderr.strip() if r.returncode != 0 else ""
-    except Exception as e:
-        lines, error = [], str(e)
+async def api_journal(request: Request, unit: str, n: int = 200):
+    """Return the last n lines of the unit's log file, falling back to journalctl."""
+    lines: list[str] = []
+    error: str = ""
+
+    log_path = _unit_log_file(unit)
+    if log_path:
+        try:
+            combined: list[str] = []
+            # Include the most recent uncompressed rotated file (delaycompress),
+            # giving ~1-2 nights of history in the viewer.
+            rotated = sorted(log_path.parent.glob(
+                f"{log_path.name}-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
+            ))
+            if rotated:
+                combined += rotated[-1].read_text(errors="replace").splitlines()
+            combined += log_path.read_text(errors="replace").splitlines()
+            lines = combined[-n:]
+        except Exception as e:
+            error = str(e)
+    else:
+        try:
+            r = subprocess.run(
+                ["journalctl", "-u", unit, "-n", str(n), "--no-pager",
+                 "--output=short-iso", "--no-hostname"],
+                capture_output=True, text=True, timeout=8
+            )
+            lines = r.stdout.splitlines() if r.returncode == 0 else []
+            error = r.stderr.strip() if r.returncode != 0 else ""
+        except Exception as e:
+            error = str(e)
+
     return templates.TemplateResponse("partials/journal.html", {
         "request": request,
         "unit":    unit,

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -70,6 +70,18 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 3b. systemd-journal group (needed to read journalctl logs in the UI)
+# ---------------------------------------------------------------------------
+if id -nG "$WEB_USER" | grep -qw systemd-journal; then
+    ok "$WEB_USER is already in the systemd-journal group"
+else
+    info "Adding $WEB_USER to the systemd-journal group (needed for log viewer)..."
+    usermod -aG systemd-journal "$WEB_USER"
+    ok "Added — service must be restarted for the new group to take effect"
+fi
+echo
+
+# ---------------------------------------------------------------------------
 # 4. Write web/.env
 # ---------------------------------------------------------------------------
 ENV_FILE="$SCRIPT_DIR/.env"

--- a/web/templates/partials/journal.html
+++ b/web/templates/partials/journal.html
@@ -3,13 +3,6 @@
 {% elif not lines %}
 <div class="text-zinc-500 text-xs font-mono p-4">No journal entries found for this unit.</div>
 {% else %}
-<pre id="journal-pre-{{ unit | replace('@','_') | replace('.','_') | replace('-','_') }}"
-     class="flex-1 text-xs font-mono text-zinc-300 leading-5 whitespace-pre-wrap break-all p-3 overflow-y-auto h-full">{% for line in lines %}{{ line }}
+<pre class="flex-1 text-xs font-mono text-zinc-300 leading-5 whitespace-pre-wrap break-all p-3 overflow-y-auto h-full">{% for line in lines %}{{ line }}
 {% endfor %}</pre>
-<script>
-(function() {
-  var el = document.getElementById("journal-pre-{{ unit | replace('@','_') | replace('.','_') | replace('-','_') }}");
-  if (el) el.scrollTop = el.scrollHeight;
-})();
-</script>
 {% endif %}

--- a/web/templates/run.html
+++ b/web/templates/run.html
@@ -156,7 +156,15 @@
     <div class="flex items-center justify-between px-4 py-2.5 border-b border-zinc-700 shrink-0">
       <span id="journal-modal-title" class="text-xs font-mono text-zinc-300"></span>
       <div class="flex items-center gap-3">
-        <span class="text-xs text-zinc-500">auto-refresh 3s</span>
+        <label for="journal-refresh-select" class="text-xs text-zinc-500">Refresh</label>
+        <select id="journal-refresh-select"
+                onchange="setJournalRefresh(this.value)"
+                class="text-xs bg-zinc-800 border border-zinc-700 text-zinc-300 rounded px-1.5 py-0.5 focus:outline-none cursor-pointer">
+          <option value="0">Off</option>
+          <option value="5000">5s</option>
+          <option value="10000" selected>10s</option>
+          <option value="30000">30s</option>
+        </select>
         <button onclick="closeJournalModal()"
                 class="text-zinc-400 hover:text-white transition-colors text-lg leading-none">&times;</button>
       </div>
@@ -171,14 +179,44 @@
 <script>
 let _journalUnit = null;
 let _journalTimer = null;
+let _journalAtBottom = true;
+let _journalSavedScroll = null;
+
+const _journalBody = document.getElementById('journal-modal-body');
+
+_journalBody.addEventListener('htmx:beforeSwap', function() {
+  const pre = this.querySelector('pre');
+  if (!pre) return;
+  _journalAtBottom = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 20;
+  _journalSavedScroll = _journalAtBottom ? null : pre.scrollTop;
+});
+
+_journalBody.addEventListener('htmx:afterSwap', function() {
+  const pre = this.querySelector('pre');
+  if (!pre) return;
+  if (_journalAtBottom) {
+    pre.scrollTop = pre.scrollHeight;
+  } else if (_journalSavedScroll !== null) {
+    pre.scrollTop = _journalSavedScroll;
+  }
+});
 
 function openJournalModal(unit) {
   _journalUnit = unit;
+  _journalAtBottom = true;
   document.getElementById('journal-modal-title').textContent = unit;
   document.getElementById('journal-modal').classList.remove('hidden');
   document.getElementById('journal-modal').classList.add('flex');
   loadJournal();
-  _journalTimer = setInterval(loadJournal, 3000);
+  const interval = parseInt(document.getElementById('journal-refresh-select').value, 10);
+  if (interval > 0) _journalTimer = setInterval(loadJournal, interval);
+}
+
+function setJournalRefresh(value) {
+  clearInterval(_journalTimer);
+  _journalTimer = null;
+  const interval = parseInt(value, 10);
+  if (interval > 0 && _journalUnit) _journalTimer = setInterval(loadJournal, interval);
 }
 
 function closeJournalModal() {
@@ -187,7 +225,7 @@ function closeJournalModal() {
   _journalUnit  = null;
   document.getElementById('journal-modal').classList.add('hidden');
   document.getElementById('journal-modal').classList.remove('flex');
-  document.getElementById('journal-modal-body').innerHTML = '<div class="text-zinc-500 text-xs font-mono p-4">Loading…</div>';
+  _journalBody.innerHTML = '<div class="text-zinc-500 text-xs font-mono p-4">Loading…</div>';
 }
 
 function loadJournal() {
@@ -198,7 +236,6 @@ function loadJournal() {
   });
 }
 
-// Close on Escape
 document.addEventListener('keydown', e => { if (e.key === 'Escape') closeJournalModal(); });
 </script>
 {% endblock %}


### PR DESCRIPTION
…missions

Runner (fs-runner.sh):
- Carry forward fsbackup_snapshot_last_success on failure so Grafana retains last-known-good timestamp across consecutive failure runs
- Log "Snapshot complete" / "Snapshot FAILED (exit N)" to backup.log so the log file is useful for diagnosis

Web UI (main.py, run.html, journal.html):
- Replace journalctl with log file reads for runner, doctor, mirror, promote, s3-export units — shows full per-target detail instead of sparse journal output
- Include previous night's uncompressed rotated log file to give ~1-2 nights of history in the viewer (respects delaycompress logrotate setup)
- Replace hardcoded 3s auto-refresh with Off/5s/10s/30s dropdown (default 10s)
- Preserve scroll position on refresh — stays at reading position when scrolled up; follows tail only when already at the bottom

Setup / docs (setup.sh, README.md):
- Add fsbackup user to systemd-journal group so fallback journalctl reads work