### PR TITLE
Log rsync stderr to backup.log for visibility on failures

### DIFF
--- a/bin/fs-runner.sh
+++ b/bin/fs-runner.sh
@@ -169,12 +169,21 @@ for t in "${TARGETS[@]}"; do
   [[ -n "$rsync_opts" ]] && RSYNC_CMD+=($rsync_opts)
 
   RSYNC_STATS_TMP="$(mktemp)"
+  RSYNC_ERR_TMP="$(mktemp)"
   if is_local_host "$host"; then
-    "${RSYNC_CMD[@]}" "${src%/}/" "$DEST/" | tee "$RSYNC_STATS_TMP"
+    "${RSYNC_CMD[@]}" "${src%/}/" "$DEST/" 2>"$RSYNC_ERR_TMP" | tee "$RSYNC_STATS_TMP"
   else
-    "${RSYNC_CMD[@]}" "${BACKUP_SSH_USER}@${host}:${src%/}/" "$DEST/" | tee "$RSYNC_STATS_TMP"
+    "${RSYNC_CMD[@]}" "${BACKUP_SSH_USER}@${host}:${src%/}/" "$DEST/" 2>"$RSYNC_ERR_TMP" | tee "$RSYNC_STATS_TMP"
   fi
   rc=${PIPESTATUS[0]}
+
+  # Log any rsync stderr output so errors appear in backup.log
+  if [[ -s "$RSYNC_ERR_TMP" ]]; then
+    while IFS= read -r errline; do
+      log "$id" "rsync: $errline"
+    done < "$RSYNC_ERR_TMP"
+  fi
+  rm -f "$RSYNC_ERR_TMP"
 
   if [[ $rc -eq 0 ]]; then
     ((SUCCEEDED++))


### PR DESCRIPTION
rsync error output (stderr) was only going to the systemd journal, not to backup.log, making it invisible in the web UI log viewer. Capture stderr to a temp file and write each line to the log with the target ID prefix so errors are visible alongside the exit code.