### PR TITLE
Make favicon adaptive for light/dark browser tabs

### DIFF
--- a/web/static/favicon.svg
+++ b/web/static/favicon.svg
@@ -1,32 +1,46 @@
-
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-<defs>
-<radialGradient id="disc" cx="40%" cy="40%" r="70%">
-<stop offset="0%" stop-color="#4b4f55"/>
-<stop offset="60%" stop-color="#2f3338"/>
-<stop offset="100%" stop-color="#1b1e22"/>
-</radialGradient>
-</defs>
+<style>
+  /* Fallback: brand orange works on both light and dark tabs in browsers
+     that don't support prefers-color-scheme in SVG favicons */
+  :root { color: #f97316; }
+  @media (prefers-color-scheme: light) { :root { color: #1c1917; } }
+  @media (prefers-color-scheme: dark)  { :root { color: #f4f4f5; } }
+</style>
 
-<rect width="100%" height="100%" fill="#111316"/>
+<!-- Disc outline -->
+<circle cx="130" cy="128" r="92" fill="none" stroke="currentColor" stroke-width="6"/>
 
-<circle cx="130" cy="128" r="92" fill="url(#disc)" stroke="#c9ccd1" stroke-width="3"/>
+<!-- Hub: ring + center dot -->
+<circle cx="130" cy="128" r="24" fill="none" stroke="currentColor" stroke-width="5"/>
+<circle cx="130" cy="128" r="9" fill="currentColor"/>
 
-<!-- orange reflections -->
-<path d="M130 128 L70 60 A80 80 0 0 1 130 48 Z" fill="#ff9f2a" opacity=".45"/>
-<path d="M130 128 L200 70 A80 80 0 0 1 160 40 Z" fill="#ffc166" opacity=".35"/>
-<path d="M130 128 L190 180 A80 80 0 0 1 150 210 Z" fill="#ff7a18" opacity=".35"/>
-<path d="M130 128 L70 180 A80 80 0 0 1 50 140 Z" fill="#ffd9a0" opacity=".25"/>
-
-<!-- hub -->
-<circle cx="130" cy="128" r="36" fill="#2c2f34"/>
-<circle cx="130" cy="128" r="24" fill="#9aa0a6"/>
-<circle cx="130" cy="128" r="10" fill="#111316"/>
-
-<!-- snowflake -->
-<g transform="translate(214.64,169.4)">
-<g stroke="#ffffff" stroke-width="4" stroke-linecap="round"><line x1="0" y1="0" x2="29.0" y2="0.0" /><line x1="15.950000000000001" y1="0.0" x2="22.982126278729645" y2="-4.06" /><line x1="15.950000000000001" y1="0.0" x2="22.982126278729645" y2="4.06" /><line x1="0" y1="0" x2="14.500000000000004" y2="25.11473670974872" /><line x1="7.975000000000002" y1="13.813105190361796" x2="15.007126278729645" y2="17.873105190361795" /><line x1="7.975000000000002" y1="13.813105190361796" x2="7.975000000000003" y2="21.933105190361797" /><line x1="0" y1="0" x2="-14.499999999999993" y2="25.114736709748723" /><line x1="-7.974999999999997" y1="13.813105190361798" x2="-7.974999999999996" y2="21.9331051903618" /><line x1="-7.974999999999997" y1="13.813105190361798" x2="-15.00712627872964" y2="17.873105190361798" /><line x1="0" y1="0" x2="-29.0" y2="3.5514757175273244e-15" /><line x1="-15.950000000000001" y1="1.9533116446400285e-15" x2="-22.982126278729645" y2="4.060000000000001" /><line x1="-15.950000000000001" y1="1.9533116446400285e-15" x2="-22.982126278729645" y2="-4.06" /><line x1="0" y1="0" x2="-14.500000000000012" y2="-25.114736709748712" /><line x1="-7.975000000000008" y1="-13.813105190361792" x2="-15.00712627872965" y2="-17.873105190361795" /><line x1="-7.975000000000008" y1="-13.813105190361792" x2="-7.975000000000009" y2="-21.933105190361793" /><line x1="0" y1="0" x2="14.500000000000004" y2="-25.11473670974872" /><line x1="7.975000000000002" y1="-13.813105190361796" x2="7.9750000000000005" y2="-21.933105190361797" /><line x1="7.975000000000002" y1="-13.813105190361796" x2="15.007126278729643" y2="-17.873105190361798" /></g><circle cx="29.0" cy="0.0" r="4.8" fill="#ffffff" /><circle cx="14.500000000000004" cy="25.11473670974872" r="4.8" fill="#ffffff" /><circle cx="-14.499999999999993" cy="25.114736709748723" r="4.8" fill="#ffffff" /><circle cx="-29.0" cy="3.5514757175273244e-15" r="4.8" fill="#ffffff" /><circle cx="-14.500000000000012" cy="-25.114736709748712" r="4.8" fill="#ffffff" /><circle cx="14.500000000000004" cy="-25.11473670974872" r="4.8" fill="#ffffff" />
+<!-- Snowflake -->
+<g transform="translate(214.64,169.4)" stroke="currentColor" stroke-width="4" stroke-linecap="round" fill="none">
+  <line x1="0" y1="0" x2="29" y2="0"/>
+  <line x1="15.95" y1="0" x2="22.98" y2="-4.06"/>
+  <line x1="15.95" y1="0" x2="22.98" y2="4.06"/>
+  <line x1="0" y1="0" x2="14.5" y2="25.11"/>
+  <line x1="7.975" y1="13.81" x2="15.007" y2="17.87"/>
+  <line x1="7.975" y1="13.81" x2="7.975" y2="21.93"/>
+  <line x1="0" y1="0" x2="-14.5" y2="25.11"/>
+  <line x1="-7.975" y1="13.81" x2="-7.975" y2="21.93"/>
+  <line x1="-7.975" y1="13.81" x2="-15.007" y2="17.87"/>
+  <line x1="0" y1="0" x2="-29" y2="0"/>
+  <line x1="-15.95" y1="0" x2="-22.98" y2="4.06"/>
+  <line x1="-15.95" y1="0" x2="-22.98" y2="-4.06"/>
+  <line x1="0" y1="0" x2="-14.5" y2="-25.11"/>
+  <line x1="-7.975" y1="-13.81" x2="-15.007" y2="-17.87"/>
+  <line x1="-7.975" y1="-13.81" x2="-7.975" y2="-21.93"/>
+  <line x1="0" y1="0" x2="14.5" y2="-25.11"/>
+  <line x1="7.975" y1="-13.81" x2="7.975" y2="-21.93"/>
+  <line x1="7.975" y1="-13.81" x2="15.007" y2="-17.87"/>
 </g>
-
-
+<g transform="translate(214.64,169.4)" fill="currentColor">
+  <circle cx="29" cy="0" r="4.8"/>
+  <circle cx="14.5" cy="25.11" r="4.8"/>
+  <circle cx="-14.5" cy="25.11" r="4.8"/>
+  <circle cx="-29" cy="0" r="4.8"/>
+  <circle cx="-14.5" cy="-25.11" r="4.8"/>
+  <circle cx="14.5" cy="-25.11" r="4.8"/>
+</g>
 </svg>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -55,7 +55,7 @@
   <aside class="w-56 shrink-0 bg-white dark:bg-zinc-900 border-r border-zinc-200 dark:border-zinc-800 flex flex-col">
     <div class="px-5 py-5 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between">
       <div class="flex items-center gap-2.5">
-        <img src="/static/icon.svg" alt="" class="h-7 w-7 rounded-lg shrink-0"/>
+        <img src="/static/icon.svg" alt="" class="h-9 w-9 rounded-lg shrink-0"/>
         <div>
           <span class="text-base font-bold tracking-tight text-zinc-900 dark:text-white">fsbackup</span>
           <span class="block text-xs text-zinc-400 mt-0.5">backup manager</span>


### PR DESCRIPTION
Replace opaque favicon with transparent outline-only SVG using currentColor + CSS prefers-color-scheme media query so the disc/hub/ snowflake icon contrasts correctly against both light and dark browser tab bars. Also bump sidebar icon from h-7 to h-9 to match text height.