### PR TITLE
Fix favicon, logos, and sidebar icon for light/dark mode

### DIFF
--- a/web/static/favicon.svg
+++ b/web/static/favicon.svg
@@ -1,21 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-<style>
-  /* Fallback: brand orange works on both light and dark tabs in browsers
-     that don't support prefers-color-scheme in SVG favicons */
-  :root { color: #f97316; }
-  @media (prefers-color-scheme: light) { :root { color: #1c1917; } }
-  @media (prefers-color-scheme: dark)  { :root { color: #f4f4f5; } }
-</style>
+<defs>
+<radialGradient id="disc" cx="40%" cy="40%" r="70%">
+<stop offset="0%" stop-color="#4b4f55"/>
+<stop offset="60%" stop-color="#2f3338"/>
+<stop offset="100%" stop-color="#1b1e22"/>
+</radialGradient>
+</defs>
 
-<!-- Disc outline -->
-<circle cx="130" cy="128" r="92" fill="none" stroke="currentColor" stroke-width="6"/>
+<!-- Disc (no background rect — transparent outside disc) -->
+<circle cx="130" cy="128" r="92" fill="url(#disc)" stroke="#c9ccd1" stroke-width="3"/>
 
-<!-- Hub: ring + center dot -->
-<circle cx="130" cy="128" r="24" fill="none" stroke="currentColor" stroke-width="5"/>
-<circle cx="130" cy="128" r="9" fill="currentColor"/>
+<!-- Orange reflections -->
+<path d="M130 128 L70 60 A80 80 0 0 1 130 48 Z" fill="#ff9f2a" opacity=".45"/>
+<path d="M130 128 L200 70 A80 80 0 0 1 160 40 Z" fill="#ffc166" opacity=".35"/>
+<path d="M130 128 L190 180 A80 80 0 0 1 150 210 Z" fill="#ff7a18" opacity=".35"/>
+<path d="M130 128 L70 180 A80 80 0 0 1 50 140 Z" fill="#ffd9a0" opacity=".25"/>
 
-<!-- Snowflake -->
-<g transform="translate(214.64,169.4)" stroke="currentColor" stroke-width="4" stroke-linecap="round" fill="none">
+<!-- Hub -->
+<circle cx="130" cy="128" r="36" fill="#2c2f34"/>
+<circle cx="130" cy="128" r="24" fill="#9aa0a6"/>
+<circle cx="130" cy="128" r="10" fill="#1b1e22"/>
+
+<!-- Snowflake (white, always visible against the dark disc) -->
+<g transform="translate(214.64,169.4)" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none">
   <line x1="0" y1="0" x2="29" y2="0"/>
   <line x1="15.95" y1="0" x2="22.98" y2="-4.06"/>
   <line x1="15.95" y1="0" x2="22.98" y2="4.06"/>
@@ -35,7 +42,7 @@
   <line x1="7.975" y1="-13.81" x2="7.975" y2="-21.93"/>
   <line x1="7.975" y1="-13.81" x2="15.007" y2="-17.87"/>
 </g>
-<g transform="translate(214.64,169.4)" fill="currentColor">
+<g transform="translate(214.64,169.4)" fill="#ffffff">
   <circle cx="29" cy="0" r="4.8"/>
   <circle cx="14.5" cy="25.11" r="4.8"/>
   <circle cx="-14.5" cy="25.11" r="4.8"/>

--- a/web/static/icon.svg
+++ b/web/static/icon.svg
@@ -8,8 +8,6 @@
 </radialGradient>
 </defs>
 
-<rect width="100%" height="100%" fill="#111316"/>
-
 <circle cx="130" cy="128" r="92" fill="url(#disc)" stroke="#c9ccd1" stroke-width="3"/>
 
 <!-- orange reflections -->

--- a/web/static/logo-dark.svg
+++ b/web/static/logo-dark.svg
@@ -8,8 +8,6 @@
 </radialGradient>
 </defs>
 
-<rect width="100%" height="100%" fill="#111316"/>
-
 <circle cx="130" cy="128" r="92" fill="url(#disc)" stroke="#c9ccd1" stroke-width="3"/>
 
 <!-- orange reflections -->

--- a/web/static/logo-light.svg
+++ b/web/static/logo-light.svg
@@ -8,8 +8,6 @@
 </radialGradient>
 </defs>
 
-<rect width="100%" height="100%" fill="#ffffff"/>
-
 <circle cx="130" cy="128" r="92" fill="url(#disc)" stroke="#c9ccd1" stroke-width="3"/>
 
 <!-- orange reflections -->
@@ -29,7 +27,7 @@
 </g>
 
 
-        <text x="260" y="120" font-family="Inter,Arial,sans-serif" font-size="56" fill="#e6e8eb" font-weight="700">fsbackup</text>
-        <text x="262" y="155" font-family="Inter,Arial,sans-serif" font-size="22" fill="#b9bec5">frozen snapshot backup</text>
+        <text x="260" y="120" font-family="Inter,Arial,sans-serif" font-size="56" fill="#18181b" font-weight="700">fsbackup</text>
+        <text x="262" y="155" font-family="Inter,Arial,sans-serif" font-size="22" fill="#52525b">frozen snapshot backup</text>
         
 </svg>


### PR DESCRIPTION
- favicon.svg: replace unreliable currentColor/CSS approach with explicit hardcoded colors (matches icon.svg design); works reliably in Firefox
- icon.svg: remove dark background rect so disc floats naturally in light and dark mode sidebars
- logo-light.svg: remove white background rect; darken text to #18181b/#52525b so it's visible on the light login page background
- logo-dark.svg: remove dark background rect so it blends into dark page bg