### PR TITLE
Add Docker deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 fsbackup is a pull-based snapshot backup system for home lab Linux servers. The backup host connects outbound over SSH to each source host, pulls data with rsync, and stores point-in-time snapshots organized by date and tier. Snapshots are mirrored to a second local drive and optionally exported to encrypted offsite archives in S3. A [browser-based web UI](#web-ui) provides monitoring, snapshot browsing, and restore — including an S3 bucket browser.
 
+fsbackup runs as a Docker container (supercronic scheduler + FastAPI web UI). See [Docker deployment](docs/docker.md) for setup instructions.
+
 ---
 
 ## Features
@@ -39,15 +41,14 @@ fsbackup is designed around the [3-2-1 backup rule](https://www.backblaze.com/bl
 - [Repository layout](#repository-layout)
 - [Data classes](#data-classes)
 - [Snapshot layout](#snapshot-layout)
-- [Scripts — automated](#scripts--automated-run-by-systemd-timers)
+- [Scripts — automated](#scripts--automated-run-by-supercronic)
 - [Scripts — manual use](#scripts--manual-use-administrative-utilities)
 - [Remote scripts](#remote-scripts)
 - [S3 cloud export](#s3-cloud-export)
-- [Daily timer schedule](#daily-timer-schedule)
+- [Daily schedule](#daily-schedule)
 - [Prometheus metrics](#prometheus-metrics)
 - [Restore](#restore)
 - [Restore from S3](#restore-from-s3)
-- [Deploying systemd unit changes](#deploying-systemd-unit-changes)
 - [Further reading](#further-reading)
 
 ---
@@ -93,12 +94,14 @@ fsbackup includes a browser-based UI for monitoring backup status, browsing snap
 ## Repository layout
 
 ```
-bin/        Scripts run automatically by systemd timers
+bin/        Scripts run automatically by supercronic (scheduler inside the container)
+docker/     Docker entrypoint script
 utils/      Manual-use administrative tools
 remote/     Scripts that run ON source hosts (not the backup server)
-s3/         S3 cloud export (in development)
-systemd/    Systemd unit files — source of truth for all timers and services
+s3/         S3 cloud export
+systemd/    Systemd unit files (reference only — not used in Docker deployment)
 conf/       Configuration templates and examples
+web/        FastAPI + HTMX web UI
 docs/       Detailed documentation
 ```
 
@@ -140,23 +143,23 @@ Snapshots are stored under `/backup/snapshots/` and mirrored to `/backup2/snapsh
 
 ---
 
-## Scripts — automated (run by systemd timers)
+## Scripts — automated (run by supercronic)
 
-These scripts are called by systemd on a schedule. You generally don't run them by hand, though you can pass `--dry-run` to test without making changes.
+These scripts are called by supercronic on a schedule. You generally don't run them by hand, though you can pass `--dry-run` to test without making changes. To run manually: `docker exec -it fsbackup /opt/fsbackup/bin/<script> ...`
 
 Repository path: **bin/**
 
 | Filename | Name | Description |
 |----------|------|-------------|
-| `fs-runner.sh` | Take a snapshot | Connects to each target over SSH and rsyncs a new snapshot. Unchanged files are hardlinked to the previous snapshot. Writes Prometheus metrics. Called by `fsbackup-runner@<class>.timer`. |
-| `fs-doctor.sh` | Health check | Checks SSH connectivity, source paths, and snapshot directories. Reports orphaned targets and verifies snapshot immutability. Called by `fsbackup-doctor@<class>.timer`. |
-| `fs-promote.sh` | Promote snapshots | Promotes qualifying daily snapshots to weekly and weekly to monthly. Runs nightly after the backup cycle. Called by `fsbackup-promote.timer`. |
-| `fs-annual-promote.sh` | Annual promotion | Promotes the prior December monthly snapshot to the `annual/` tier (class1 only). Runs January 5th. Called by `fsbackup-annual-promote.timer`. |
-| `fs-retention.sh` | Prune old snapshots | Deletes snapshots past retention limits on primary storage (14d daily / 8w weekly / 12m monthly). Called by `fsbackup-retention.timer`. |
-| `fs-mirror.sh` | Sync to mirror drive | Rsyncs primary snapshots to the secondary drive. Runs in `daily` or `promote` mode. Skips classes in `MIRROR_SKIP_CLASSES`. Called by `fsbackup-mirror-daily.timer` and `fsbackup-mirror-promote.timer`. |
-| `fs-mirror-retention.sh` | Prune mirror snapshots | Prunes old snapshots on the mirror drive (14d / 12w / 24m). Called by `fsbackup-mirror-retention.timer`. |
-| `fs-db-export.sh` | Export databases | Dumps databases to an export directory so the runner captures a consistent snapshot instead of live files. Called by `fs-db-export@<app>.timer`. |
-| `fs-logrotate-metric.sh` | Logrotate health metric | Checks that logrotate ran and writes a Prometheus metric for alerting. Called by `fsbackup-logrotate-metric.timer`. |
+| `fs-runner.sh` | Take a snapshot | Connects to each target over SSH and rsyncs a new snapshot. Unchanged files are hardlinked to the previous snapshot. Writes Prometheus metrics. |
+| `fs-doctor.sh` | Health check | Checks SSH connectivity, source paths, and snapshot directories. Reports orphaned targets and verifies snapshot immutability. |
+| `fs-promote.sh` | Promote snapshots | Promotes qualifying daily snapshots to weekly and weekly to monthly. Runs nightly after the backup cycle. |
+| `fs-annual-promote.sh` | Annual promotion | Promotes the prior December monthly snapshot to the `annual/` tier (class1 only). Runs January 5th. |
+| `fs-retention.sh` | Prune old snapshots | Deletes snapshots past retention limits on primary storage (14d daily / 8w weekly / 12m monthly). |
+| `fs-mirror.sh` | Sync to mirror drive | Rsyncs primary snapshots to the secondary drive. Runs in `daily` or `promote` mode. Skips classes in `MIRROR_SKIP_CLASSES`. |
+| `fs-mirror-retention.sh` | Prune mirror snapshots | Prunes old snapshots on the mirror drive (14d / 12w / 24m). |
+| `fs-db-export.sh` | Export databases | Dumps databases via `docker exec` to an export directory before backup runs, ensuring a consistent snapshot. Requires Docker socket mount. |
+| `fs-logrotate-metric.sh` | Logrotate health metric | Checks that logrotate ran and writes a Prometheus metric for alerting. |
 
 ---
 
@@ -194,7 +197,7 @@ Repository path: **remote/**
 
 `s3/fs-export-s3.sh` compresses, encrypts, and uploads snapshots to Amazon S3 for offsite storage. Weekly, monthly, and annual snapshots are exported; daily snapshots and class3 are not. Files are encrypted with [age](https://github.com/FiloSottile/age) before upload so S3 never holds readable data. Retention is managed entirely by S3 lifecycle rules — the script never deletes anything.
 
-Called by: `fsbackup-s3-export.timer` (04:30 daily, after mirror-promote)
+Called by: supercronic at 04:30 daily, after mirror-promote.
 
 ### S3 setup
 
@@ -307,7 +310,7 @@ Test it:
 sudo -u fsbackup aws s3 ls s3://fsbackup-snapshots-SUFFIX --profile fsbackup
 ```
 
-**6. Update fsbackup.conf and enable the timer**
+**6. Update fsbackup.conf**
 
 Add to `/etc/fsbackup/fsbackup.conf`:
 
@@ -316,19 +319,11 @@ S3_BUCKET="fsbackup-snapshots-SUFFIX"
 S3_SKIP_CLASSES="class3"
 ```
 
-Then deploy and enable:
-
-```bash
-sudo cp /opt/fsbackup/systemd/fsbackup-s3-export.service \
-        /opt/fsbackup/systemd/fsbackup-s3-export.timer \
-        /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now fsbackup-s3-export.timer
-```
+The S3 export runs automatically via supercronic at 04:30 daily once the container is running.
 
 ---
 
-## Daily timer schedule
+## Daily schedule
 
 | Time | Job |
 |------|-----|
@@ -423,7 +418,7 @@ Written after each S3 export run.
 
 ## Restore
 
-Use `utils/fs-restore.sh` as the `fsbackup` system user or as root.
+Use `utils/fs-restore.sh` via `docker exec` or directly as the `fsbackup` user. Restored files land in `/restore` inside the container, which maps to `/backup/restore` on the host.
 
 ### Browse available snapshots
 
@@ -445,17 +440,17 @@ fs-restore.sh list --type monthly --date 2026-02     --class class1
 ### Restore to a local path
 
 ```bash
-# Restore the most recent daily snapshot to /tmp/restore-nginx
-fs-restore.sh restore \
+# Restore the most recent daily snapshot to /restore/nginx (→ /backup/restore/nginx on host)
+docker exec -it fsbackup /opt/fsbackup/utils/fs-restore.sh restore \
   --type daily --class class2 --id nginx.data \
   --latest \
-  --to /tmp/restore-nginx
+  --to /restore/nginx
 
 # Restore from a specific date
-fs-restore.sh restore \
+docker exec -it fsbackup /opt/fsbackup/utils/fs-restore.sh restore \
   --type weekly --class class2 --id ns1.bind.named.conf \
   --date 2026-W09 \
-  --to /tmp/restore-bind
+  --to /restore/bind
 ```
 
 ### Restore directly to a remote host
@@ -464,13 +459,13 @@ The script rsyncs the snapshot to `backup@<host>:<path>` over SSH using the same
 
 ```bash
 # Restore bind config to ns1 at a staging path
-fs-restore.sh restore \
+docker exec -it fsbackup /opt/fsbackup/utils/fs-restore.sh restore \
   --type daily --class class2 --id ns1.bind.named.conf \
   --latest \
   --to-host ns1 --to-path /tmp/restore-bind
 
 # Restore from a specific weekly snapshot to ns2
-fs-restore.sh restore \
+docker exec -it fsbackup /opt/fsbackup/utils/fs-restore.sh restore \
   --type weekly --class class2 --id ns2.bind.named.conf \
   --date 2026-W09 \
   --to-host ns2 --to-path /tmp/restore-bind
@@ -565,19 +560,9 @@ annual/class1/homeassistant.db/homeassistant.db--2025.tar.zst.age
 
 ---
 
-## Deploying systemd unit changes
-
-The `systemd/` directory is the source of truth. After editing unit files:
-
-```bash
-sudo cp /opt/fsbackup/systemd/*.service /opt/fsbackup/systemd/*.timer /etc/systemd/system/
-sudo systemctl daemon-reload
-```
-
----
-
 ## Further reading
 
+- [Docker deployment](docs/docker.md)
 - [Installation](docs/installation.md)
 - [Adding hosts and targets](docs/adding-hosts-and-targets.md)
 - [Operations guide](docs/operations.md)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,502 @@
+# Docker Deployment — fsbackup
+
+This guide covers running fsbackup entirely inside a Docker container. The container replaces systemd timers (supercronic handles scheduling), the web UI runs on port 8080, and all persistent state lives on bind-mounted host paths so the container is stateless and upgradeable.
+
+---
+
+## Prerequisites
+
+- Docker Engine (with Compose v2) on the host
+- A dedicated backup drive mounted at `/backup` (primary snapshots)
+- A mirror drive mounted at `/backup2` (optional but recommended)
+- The `fsbackup` system user already created on the host with UID/GID **993:993**
+
+If the user does not exist yet:
+
+```bash
+useradd -r -u 993 -g 993 -m -d /var/lib/fsbackup -s /bin/bash fsbackup
+```
+
+Confirm:
+
+```bash
+id fsbackup
+# uid=993(fsbackup) gid=993(fsbackup) groups=993(fsbackup)
+```
+
+The container runs as `993:993`. Files written by the container (snapshots, logs, metrics) will be owned by this UID on the host.
+
+---
+
+## Before You Begin — One-Time Host Setup
+
+Complete these steps once before starting the container for the first time.
+
+### 1. Create required directories
+
+```bash
+mkdir -p /backup/snapshots/{daily,weekly,monthly,annual}
+mkdir -p /backup2/snapshots/{daily,weekly,monthly,annual}
+mkdir -p /backup/exports
+mkdir -p /backup/restore
+mkdir -p /var/lib/fsbackup/{.ssh,.aws,log}
+mkdir -p /etc/fsbackup/db
+
+chown -R fsbackup:fsbackup /backup/snapshots /backup2/snapshots
+chown -R fsbackup:fsbackup /backup/exports /backup/restore
+chown -R fsbackup:fsbackup /var/lib/fsbackup
+chown -R fsbackup:fsbackup /etc/fsbackup
+```
+
+### 2. Write the config files
+
+```bash
+# Copy examples from the repo
+cp /opt/fsbackup/conf/fsbackup.conf.example /etc/fsbackup/fsbackup.conf
+cp /opt/fsbackup/conf/targets.yml.example   /etc/fsbackup/targets.yml
+cp /opt/fsbackup/conf/fsbackup.crontab      /etc/fsbackup/fsbackup.crontab
+```
+
+Edit `/etc/fsbackup/fsbackup.conf` at minimum:
+
+```bash
+SNAPSHOT_ROOT="/backup/snapshots"
+SNAPSHOT_MIRROR_ROOT="/backup2/snapshots"
+MIRROR_SKIP_CLASSES="class3"
+```
+
+Edit `/etc/fsbackup/targets.yml` with your hosts and paths. Targets that previously used `host: fs` (local host) must use `host: localhost` in Docker, and those source paths must be bind-mounted into the container (see [Volumes reference](#volumes-reference) below).
+
+### 3. Generate the backup SSH keypair
+
+```bash
+sudo -u fsbackup ssh-keygen -t ed25519 \
+  -f /var/lib/fsbackup/.ssh/id_ed25519 -N ""
+chmod 700 /var/lib/fsbackup/.ssh
+chmod 600 /var/lib/fsbackup/.ssh/id_ed25519
+```
+
+Install the public key on each remote host (see [adding-hosts-and-targets.md](adding-hosts-and-targets.md)).
+
+### 4. Set up AWS credentials (S3 export only)
+
+```bash
+mkdir -p /var/lib/fsbackup/.aws
+cat > /var/lib/fsbackup/.aws/credentials <<'EOF'
+[fsbackup]
+aws_access_key_id     = YOUR_ACCESS_KEY
+aws_secret_access_key = YOUR_SECRET_KEY
+EOF
+
+cat > /var/lib/fsbackup/.aws/config <<'EOF'
+[profile fsbackup]
+region = us-west-2
+EOF
+
+chown -R fsbackup:fsbackup /var/lib/fsbackup/.aws
+chmod 600 /var/lib/fsbackup/.aws/credentials
+```
+
+### 5. Set up the node_exporter textfile directory (optional)
+
+If you run Prometheus node_exporter with the textfile collector:
+
+```bash
+groupadd nodeexp_txt
+usermod -aG nodeexp_txt fsbackup
+mkdir -p /var/lib/node_exporter/textfile_collector
+chown root:nodeexp_txt /var/lib/node_exporter/textfile_collector
+chmod 2775 /var/lib/node_exporter/textfile_collector
+```
+
+Or use the repair utility:
+
+```bash
+sudo /opt/fsbackup/utils/fs-nodeexp-fix.sh
+```
+
+### 6. Find the Docker socket GID
+
+The container needs access to `/var/run/docker.sock` for `fs-db-export.sh` (it runs `docker exec` against the paperlessngx container).
+
+```bash
+stat -c '%g' /var/run/docker.sock
+# e.g. 129
+```
+
+Use this GID in `group_add` in the compose file (see the example below).
+
+---
+
+## Stack Compose Setup
+
+The live stack lives at `/docker/stacks/fsbackup/docker-compose.yml`. An annotated example is in `conf/docker-compose.yml.example`.
+
+A minimal working stack:
+
+```yaml
+services:
+  fsbackup:
+    container_name: fsbackup
+    image: registry.kluhsman.com/fsbackup:v0.9.1
+    restart: unless-stopped
+
+    # Must match the fsbackup user on the host.
+    user: "993:993"
+
+    # Add the Docker socket GID so db-export can run `docker exec`.
+    # Find it with: stat -c '%g' /var/run/docker.sock
+    group_add:
+      - "129"
+
+    # Bind only to the backup server's IP so the UI is not exposed to all interfaces.
+    ports:
+      - "172.30.3.130:8080:8080"
+
+    # Web UI config and credentials (see Web UI Configuration below).
+    env_file:
+      - stack.env
+
+    # Pin remote hostnames to IPs to avoid DNS failures (see Troubleshooting).
+    extra_hosts:
+      - "denhpsvr1:172.30.3.10"
+      - "denhpsvr2:172.30.3.70"
+      - "ns1:172.30.3.53"
+      - "ns2:172.30.3.54"
+      # add remaining remote backup targets here
+
+    volumes:
+      # Primary snapshot storage
+      - /backup/snapshots:/backup/snapshots
+
+      # Mirror snapshot storage (remove if no second drive)
+      - /backup2/snapshots:/backup2/snapshots
+
+      # DB export staging
+      - /backup/exports:/backup/exports
+
+      # Restore staging
+      - /backup/restore:/restore
+
+      # Prometheus textfile collector (remove if not using node_exporter)
+      - /var/lib/node_exporter/textfile_collector:/var/lib/node_exporter/textfile_collector
+
+      # fsbackup config: fsbackup.conf, targets.yml, fsbackup.crontab, age.pub, db/
+      - /etc/fsbackup:/etc/fsbackup
+
+      # fsbackup state: .ssh/, .aws/, log/
+      - /var/lib/fsbackup:/var/lib/fsbackup
+
+      # Docker socket for db-export
+      - /var/run/docker.sock:/var/run/docker.sock
+
+      # Localhost source paths (targets with host: localhost in targets.yml)
+      # Add one line per source path that is backed up from this host.
+      # Example:
+      # - /docker/stacks:/docker/stacks:ro
+      # - /share/technicom:/share/technicom:ro
+      # - /etc/apache2:/etc/apache2:ro
+```
+
+Place `stack.env` next to `docker-compose.yml` (see [Web UI Configuration](#web-ui-configuration) below).
+
+---
+
+## Volumes Reference
+
+| Host path | Container path | Purpose |
+|-----------|----------------|---------|
+| `/backup/snapshots` | `/backup/snapshots` | Primary rsync snapshot storage |
+| `/backup2/snapshots` | `/backup2/snapshots` | Mirror snapshot storage |
+| `/backup/exports` | `/backup/exports` | DB export output |
+| `/backup/restore` | `/restore` | Restore staging area |
+| `/var/lib/node_exporter/textfile_collector` | `/var/lib/node_exporter/textfile_collector` | Prometheus `.prom` metrics |
+| `/etc/fsbackup` | `/etc/fsbackup` | Config, targets.yml, crontab, age.pub, db/ env files |
+| `/var/lib/fsbackup` | `/var/lib/fsbackup` | SSH keys, AWS creds, logs |
+| `/var/run/docker.sock` | `/var/run/docker.sock` | Docker socket for db-export |
+| _(your localhost paths)_ | _(same paths)_ | Source data for `host: localhost` targets |
+
+All mounts are bind mounts. There are no named volumes. Everything persists on the host and survives container replacement.
+
+---
+
+## Web UI Configuration
+
+Create `stack.env` in the stack directory (next to `docker-compose.yml`):
+
+```bash
+# Server
+HOST=0.0.0.0
+PORT=8080
+
+# Snapshot paths (must match fsbackup.conf)
+SNAPSHOT_ROOT=/backup/snapshots
+MIRROR_ROOT=/backup2/snapshots
+TARGETS_FILE=/etc/fsbackup/targets.yml
+
+# Auth
+AUTH_ENABLED=true
+
+# Session secret — generate with:
+#   python3 -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=your-secret-here
+
+# S3 (if using)
+S3_BUCKET=fsbackup-snapshots-SUFFIX
+S3_PROFILE=fsbackup
+S3_REGION=us-west-2
+```
+
+**Important — bcrypt `$` escaping:** Docker Compose v2 interpolates `$` in env files. If `AUTH_PASSWORD_HASH` contains a bcrypt hash (which always starts with `$2b$`), every `$` must be doubled to `$$`:
+
+```bash
+# Wrong (Compose will silently corrupt the hash):
+AUTH_PASSWORD_HASH=$2b$12$abc...
+
+# Correct:
+AUTH_PASSWORD_HASH=$$2b$$12$$abc...
+```
+
+Generate a bcrypt hash:
+
+```bash
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt()).decode())"
+```
+
+Then double every `$` before pasting into `stack.env`.
+
+---
+
+## SSH Host Keys
+
+Before the container runs its first backup, you must seed known_hosts for every remote target. The file is bind-mounted from the host at `/var/lib/fsbackup/.ssh/known_hosts`, so you can populate it from either the host or the container.
+
+**From the host:**
+
+```bash
+ssh-keyscan -t ed25519 denhpsvr1 >> /var/lib/fsbackup/.ssh/known_hosts
+ssh-keyscan -t ed25519 denhpsvr2 >> /var/lib/fsbackup/.ssh/known_hosts
+# repeat for each remote target
+chown fsbackup:fsbackup /var/lib/fsbackup/.ssh/known_hosts
+chmod 600 /var/lib/fsbackup/.ssh/known_hosts
+```
+
+**From inside the container (after it is running):**
+
+```bash
+docker exec -it fsbackup /opt/fsbackup/utils/fs-trust-host.sh denhpsvr1
+docker exec -it fsbackup /opt/fsbackup/utils/fs-trust-host.sh denhpsvr2
+```
+
+Changes write through to the host bind mount immediately.
+
+---
+
+## Scheduler (Crontab)
+
+supercronic reads `/etc/fsbackup/fsbackup.crontab` at startup and hot-reloads it on change. The file is bind-mounted from the host, so you can edit it on the host and supercronic picks up the change without a container restart.
+
+The default schedule (`conf/fsbackup.crontab`):
+
+| Time | Job |
+|------|-----|
+| 00:30 daily | `fs-logrotate-metric.sh` |
+| 01:15 daily | `fs-doctor.sh --class class1` |
+| 01:40 daily | `fs-db-export.sh` (paperlessngx) |
+| 01:45 daily | `fs-runner.sh daily --class class1` |
+| 02:05 daily | `fs-doctor.sh --class class2` |
+| 02:15 daily | `fs-runner.sh daily --class class2` |
+| 02:30 daily | `fs-mirror.sh daily` |
+| 03:00 daily | `fs-retention.sh` |
+| 03:30 daily | `fs-promote.sh` |
+| 03:40 daily | `fs-mirror.sh promote` |
+| 04:00 daily | `fs-mirror-retention.sh` |
+| 04:15, 1st of month | `fs-doctor.sh --class class3` |
+| 04:30 daily | `fs-export-s3.sh` |
+| 04:45, 1st of month | `fs-runner.sh monthly --class class3` |
+| 03:00, Jan 5 | `fs-annual-promote.sh` |
+
+To disable a job, comment it out in `/etc/fsbackup/fsbackup.crontab` on the host.
+
+---
+
+## Running Jobs Manually
+
+Execute any script directly with `docker exec`:
+
+```bash
+# Dry-run snapshot for class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --dry-run
+
+# Live snapshot for class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1
+
+# Health check
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class2
+
+# Restore latest snapshot of a target to /restore/test
+docker exec -it fsbackup /opt/fsbackup/utils/fs-restore.sh restore \
+  --type daily --class class2 --id rp.nginx.config --latest --to /restore/test
+
+# Mirror
+docker exec -it fsbackup /opt/fsbackup/bin/fs-mirror.sh daily
+
+# Promote
+docker exec -it fsbackup /opt/fsbackup/bin/fs-promote.sh
+
+# Retention
+docker exec -it fsbackup /opt/fsbackup/bin/fs-retention.sh
+```
+
+Logs are written to `/var/lib/fsbackup/log/` (bind-mounted from host) and viewable via the web UI.
+
+---
+
+## Building and Pushing the Image
+
+```bash
+cd /home/crash/fsbackup   # or /opt/fsbackup
+
+docker build \
+  -t registry.kluhsman.com/fsbackup:vX.Y.Z \
+  -t registry.kluhsman.com/fsbackup:latest \
+  .
+
+docker push registry.kluhsman.com/fsbackup:vX.Y.Z
+docker push registry.kluhsman.com/fsbackup:latest
+```
+
+The image is built from repo root. Replace `vX.Y.Z` with the release tag (e.g. `v0.9.2`).
+
+---
+
+## Upgrading
+
+1. Build and push the new image (see above).
+2. On the host:
+
+```bash
+cd /docker/stacks/fsbackup
+docker compose pull
+docker compose up -d
+```
+
+`docker compose up -d` recreates the container with the new image. All state is on bind mounts, so no data is lost. The upgrade takes a few seconds; schedule it outside the backup window (before 01:00 or after 05:00).
+
+---
+
+## Troubleshooting
+
+### Permission denied writing snapshots or logs
+
+The container runs as `993:993`. Confirm ownership of the bind-mounted directories:
+
+```bash
+ls -la /backup/snapshots
+ls -la /var/lib/fsbackup
+```
+
+If directories are owned by root:
+
+```bash
+chown -R fsbackup:fsbackup /backup/snapshots /backup2/snapshots
+chown -R fsbackup:fsbackup /backup/exports /backup/restore
+chown -R fsbackup:fsbackup /var/lib/fsbackup /etc/fsbackup
+```
+
+### Docker socket permission denied (db-export fails)
+
+`fs-db-export.sh` runs `docker exec` against a container on the host. The container user (`993`) needs access to the Docker socket.
+
+Find the GID of the socket:
+
+```bash
+stat -c '%g' /var/run/docker.sock
+```
+
+Set that GID in `group_add` in the compose file. After changing `group_add`, recreate the container:
+
+```bash
+docker compose up -d
+```
+
+Verify inside the container:
+
+```bash
+docker exec -it fsbackup id
+# should show the docker GID in the groups list
+docker exec -it fsbackup docker ps
+# should succeed without permission error
+```
+
+### DNS failures for remote hosts (Linux 6.8 FIB exception bug)
+
+Linux 6.8 has an intermittent FIB exception bug that can cause TCP connections to cross-VLAN hosts to fail with `ENETUNREACH`. Docker bridge traffic is affected. The fix is to bypass DNS for backup target hostnames by pinning them to IP addresses using `extra_hosts` in the compose file:
+
+```yaml
+extra_hosts:
+  - "denhpsvr1:172.30.3.10"
+  - "denhpsvr2:172.30.3.70"
+  - "ns1:172.30.3.53"
+  - "ns2:172.30.3.54"
+```
+
+Add every remote host that appears in `targets.yml`. This injects static `/etc/hosts` entries into the container and removes the DNS lookup from the connection path entirely.
+
+### bcrypt password hash silently corrupted
+
+If web UI login fails immediately after setting `AUTH_PASSWORD_HASH`, the hash likely contains unescaped `$` signs. Docker Compose v2 interpolates `$VAR` patterns in env files.
+
+Fix: double every `$` in the hash value in `stack.env`:
+
+```bash
+# Before (broken):
+AUTH_PASSWORD_HASH=$2b$12$LongHashHere
+
+# After (correct):
+AUTH_PASSWORD_HASH=$$2b$$12$$LongHashHere
+```
+
+Restart the container after editing `stack.env`:
+
+```bash
+docker compose up -d
+```
+
+### SSH host key verification failure
+
+If a backup fails with `Host key verification failed`, the remote host's key is not in `known_hosts`. Trust the host:
+
+```bash
+# From the host (bind-mounted, takes effect immediately):
+ssh-keyscan -t ed25519 <hostname> >> /var/lib/fsbackup/.ssh/known_hosts
+
+# Or from inside the container:
+docker exec -it fsbackup /opt/fsbackup/utils/fs-trust-host.sh <hostname>
+```
+
+### Localhost source paths not found
+
+Targets with `host: localhost` in `targets.yml` expect the source path to exist inside the container. If rsync reports the source path as missing, add the corresponding bind mount to the compose file:
+
+```yaml
+volumes:
+  - /docker/stacks:/docker/stacks:ro
+  - /share/technicom:/share/technicom:ro
+  - /etc/apache2:/etc/apache2:ro
+```
+
+Then recreate the container: `docker compose up -d`.
+
+### Viewing logs
+
+```bash
+# Live supercronic output (cron job stdout/stderr)
+docker logs -f fsbackup
+
+# Per-job log files (written by the scripts)
+ls /var/lib/fsbackup/log/
+
+# Or via the web UI at http://172.30.3.130:8080
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,41 +1,41 @@
 # Installation — fsbackup backup server
 
-This document covers setting up the fsbackup system on the primary backup host (`fs`).
+This document covers setting up the fsbackup system on the primary backup host.
 For adding new source hosts, see [adding-hosts-and-targets.md](adding-hosts-and-targets.md).
+
+fsbackup runs as a Docker container. See [docker.md](docker.md) for the full Docker deployment guide. The steps below cover the one-time host preparation that Docker deployment requires.
 
 ---
 
 ## Prerequisites
 
 - Ubuntu/Debian Linux
+- Docker Engine + Docker Compose v2
 - Dedicated backup drive(s) mounted (e.g. `/backup`, `/backup2`)
-- Packages: `rsync`, `ssh`, `acl`, `yq`, `jq`
-- `node_exporter` with textfile collector (optional, for metrics)
-
-```bash
-apt install rsync openssh-client acl yq jq
-```
+- `node_exporter` with textfile collector (optional, for Prometheus metrics)
 
 ---
 
 ## 1. Clone the repository
 
 ```bash
-git clone <repo-url> /opt/fsbackup
-cd /opt/fsbackup
+git clone <repo-url> /home/<user>/fsbackup
 ```
 
-All scripts run directly from `/opt/fsbackup/bin/`. Nothing is copied to `/usr/local/sbin`.
+The repo is used for building the Docker image and as a reference. Scripts run from inside the container at `/opt/fsbackup/`.
 
 ---
 
 ## 2. Create the fsbackup system user
 
 ```bash
-useradd -r -m -d /var/lib/fsbackup -s /bin/bash fsbackup
+sudo useradd -r --uid 993 -g $(getent group | awk -F: '$3==993{print $1}' || echo fsbackup) \
+  -d /var/lib/fsbackup -s /bin/bash fsbackup 2>/dev/null || \
+sudo useradd -r -m -d /var/lib/fsbackup -s /bin/bash fsbackup
+sudo usermod -u 993 fsbackup
 ```
 
-This user runs all backup scripts via systemd. It must own its home directory and SSH key.
+The UID **must be 993** to match the user baked into the Docker image. The container runs as `user: "993:993"` and needs matching ownership on bind-mounted directories.
 
 ---
 
@@ -123,51 +123,39 @@ The web UI `install.sh` calls this automatically when the web user differs from 
 
 ---
 
-## 8. Deploy systemd units
+## 8. Deploy the Docker stack
 
-The `systemd/` directory in the repo is the source of truth for all unit files.
+See [docker.md](docker.md) for the full stack compose setup, volume configuration, and first-run steps.
 
-```bash
-sudo cp /opt/fsbackup/systemd/*.service /opt/fsbackup/systemd/*.timer /etc/systemd/system/
-sudo systemctl daemon-reload
-```
-
-Enable and start timers:
+Quick start:
 
 ```bash
-sudo systemctl enable --now \
-  fsbackup-doctor@class1.timer \
-  fsbackup-runner@class1.timer \
-  fsbackup-doctor@class2.timer \
-  fsbackup-runner@class2.timer \
-  fsbackup-doctor@class3.timer \
-  fsbackup-runner@class3.timer \
-  fsbackup-promote.timer \
-  fsbackup-mirror-daily.timer \
-  fsbackup-mirror-promote.timer \
-  fsbackup-retention.timer \
-  fsbackup-mirror-retention.timer \
-  fsbackup-annual-promote.timer
+mkdir -p /docker/stacks/fsbackup
+cp /home/<user>/fsbackup/conf/docker-compose.yml.example /docker/stacks/fsbackup/docker-compose.yml
+# Edit docker-compose.yml — set image tag, ports, volumes, extra_hosts
+cd /docker/stacks/fsbackup
+docker compose up -d
 ```
 
 ---
 
-## 9. Trust the local host SSH key
+## 9. Trust remote host SSH keys
 
-For local (`host: fs`) targets, rsync runs directly without SSH. No key trust needed.
+For each remote host that fsbackup will pull from:
 
-For any remote hosts, see [adding-hosts-and-targets.md](adding-hosts-and-targets.md).
+```bash
+docker exec -it fsbackup /opt/fsbackup/utils/fs-trust-host.sh <hostname>
+```
+
+For local (`host: localhost`) targets, no key trust is needed — rsync accesses paths directly via bind mounts.
 
 ---
 
 ## 10. Verify
 
-Run the doctor against each class to confirm all targets are reachable:
-
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class1
-sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class2
-sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class3
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class2
 ```
 
 All targets should report `OK`. Fix any `FAIL` entries before running the runner.
@@ -177,6 +165,6 @@ All targets should report `OK`. Fix any `FAIL` entries before running the runner
 ## 11. Run a first snapshot
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --dry-run
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --dry-run
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3,6 +3,8 @@
 Day-to-day management: checking health, running jobs manually, managing orphans, and
 verifying the mirror.
 
+All scripts run inside the Docker container. The examples below use `docker exec`. Replace `fsbackup` with your container name if different.
+
 ---
 
 ## Checking system health
@@ -13,9 +15,9 @@ The doctor checks SSH reachability and source path existence for all targets in 
 It also scans for orphaned snapshots and verifies annual snapshot immutability.
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class1
-sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class2
-sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class3
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class2
+docker exec -it fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class3
 ```
 
 Output:
@@ -54,12 +56,17 @@ tail -f /var/lib/fsbackup/log/annual-promote.log
 cat /var/lib/fsbackup/log/fs-orphans.log
 ```
 
-### Systemd unit status
+### Container and scheduler status
 
 ```bash
-systemctl status fsbackup-runner@class1.service
-systemctl status fsbackup-mirror-daily.service
-journalctl -u fsbackup-runner@class1.service --since today
+# Check container is running
+docker ps | grep fsbackup
+
+# Follow all output from the container (supercronic + uvicorn)
+docker logs -f fsbackup
+
+# Check supercronic job output
+docker exec -it fsbackup tail -f /var/lib/fsbackup/log/backup.log
 ```
 
 ---
@@ -69,19 +76,19 @@ journalctl -u fsbackup-runner@class1.service --since today
 ### Dry-run a snapshot (safe, no changes)
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --dry-run
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --dry-run
 ```
 
 ### Run a snapshot for real
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1
 ```
 
 ### Run a single target only
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --target mosquitto.data
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --target mosquitto.data
 ```
 
 When `--target` is used, the Prometheus metrics file is updated only for that target.
@@ -94,14 +101,14 @@ By default the runner uses `--ignore-existing` to avoid re-transferring unchange
 To force a full re-sync of an existing snapshot:
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 \
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 \
   --target mosquitto.data --replace-existing
 ```
 
 ### Run promotion manually
 
 ```bash
-sudo /opt/fsbackup/bin/fs-promote.sh
+docker exec -it fsbackup /opt/fsbackup/bin/fs-promote.sh
 ```
 
 Promotion only acts on `DOW=1` (Monday) for weekly and `DOM=01` for monthly. To test
@@ -110,24 +117,24 @@ outside those days the script will run but skip promotion — check the log.
 ### Run annual promotion manually
 
 ```bash
-sudo /opt/fsbackup/bin/fs-annual-promote.sh --dry-run
-sudo /opt/fsbackup/bin/fs-annual-promote.sh
+docker exec -it fsbackup /opt/fsbackup/bin/fs-annual-promote.sh --dry-run
+docker exec -it fsbackup /opt/fsbackup/bin/fs-annual-promote.sh
 # or for a specific year:
-sudo /opt/fsbackup/bin/fs-annual-promote.sh --year 2025
+docker exec -it fsbackup /opt/fsbackup/bin/fs-annual-promote.sh --year 2025
 ```
 
 ### Run retention manually
 
 ```bash
-sudo /opt/fsbackup/bin/fs-retention.sh
-sudo /opt/fsbackup/bin/fs-mirror-retention.sh
+docker exec -it fsbackup /opt/fsbackup/bin/fs-retention.sh
+docker exec -it fsbackup /opt/fsbackup/bin/fs-mirror-retention.sh
 ```
 
 ### Run mirror manually
 
 ```bash
-sudo /opt/fsbackup/bin/fs-mirror.sh daily
-sudo /opt/fsbackup/bin/fs-mirror.sh promote
+docker exec -it fsbackup /opt/fsbackup/bin/fs-mirror.sh daily
+docker exec -it fsbackup /opt/fsbackup/bin/fs-mirror.sh promote
 ```
 
 ---
@@ -197,7 +204,7 @@ diff -rq \
 ### Manual mirror check for annual snapshots
 
 ```bash
-sudo /opt/fsbackup/utils/fs-annual-mirror-check.sh
+docker exec -it fsbackup /opt/fsbackup/utils/fs-annual-mirror-check.sh
 ```
 
 ---
@@ -227,7 +234,7 @@ tracked in the Prometheus metric `fsbackup_runner_target_failures_total`.
 To re-run immediately for a specific target:
 
 ```bash
-sudo -u fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --target <id>
+docker exec -it fsbackup /opt/fsbackup/bin/fs-runner.sh daily --class class1 --target <id>
 ```
 
 ---
@@ -248,8 +255,8 @@ Common causes:
   that is a kernel FIB routing bug (see below).
 - **SSH host key mismatch** — the target host was rebuilt. Re-trust the key:
   ```bash
-  sudo -u fsbackup ssh-keygen -R <hostname> -f /var/lib/fsbackup/.ssh/known_hosts
-  sudo /opt/fsbackup/utils/fs-trust-host.sh <hostname>
+  ssh-keygen -R <hostname> -f /var/lib/fsbackup/.ssh/known_hosts
+  docker exec -it fsbackup /opt/fsbackup/utils/fs-trust-host.sh <hostname>
   ```
 - **SSH auth failure** — the `backup` user on the remote host does not have the correct
   authorized key. Re-run `fsbackup_remote_init.sh` on the remote host.


### PR DESCRIPTION
- Add docs/docker.md: full Docker stack setup, volumes, web UI, SSH trust, scheduler, upgrade, and troubleshooting guide
- Update README.md: Docker as primary deployment model, repo layout updated, scripts section renamed to "run by supercronic", restore commands use docker exec, systemd section removed
- Update docs/installation.md: Docker as primary path, UID 993 requirement explicit, Docker stack step replaces systemd step
- Update docs/operations.md: all management commands use docker exec, container/scheduler status section replaces systemd status