### PR TITLE
Rename setup.sh to install.sh; add web UI prompt; update docs and log…

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ For adding new source hosts, see [adding-hosts-and-targets.md](adding-hosts-and-
 | | Docker | Bare-metal |
 |---|---|---|
 | **Recommended** | Yes | For environments without Docker |
-| **Scheduler** | supercronic (in container) | systemd timers |
+| **Scheduler** | supercronic (in container) | supercronic |
 | **Scripts run as** | fsbackup user inside container | fsbackup user on host |
 | **Config location** | `/etc/fsbackup/` (bind-mounted) | `/etc/fsbackup/` |
 
@@ -30,37 +30,25 @@ git clone https://github.com/fsbackup/fsbackup /home/<user>/fsbackup
 
 ---
 
-### 2. Create the fsbackup system user
+### 2. Run the bootstrap installer
+
+`install.sh` creates the `fsbackup` system user and group, generates the SSH keypair,
+creates required directories, installs supercronic, and sets up the node_exporter
+textfile collector. It is safe to re-run at any time.
 
 ```bash
-sudo useradd -r --uid 993 -g $(getent group | awk -F: '$3==993{print $1}' || echo fsbackup) \
-  -d /var/lib/fsbackup -s /bin/bash fsbackup 2>/dev/null || \
-sudo useradd -r -m -d /var/lib/fsbackup -s /bin/bash fsbackup
-sudo usermod -u 993 fsbackup
+sudo /home/<user>/fsbackup/install.sh
 ```
 
-The UID **must be 993** to match the user baked into the Docker image. Use the same UID for bare-metal deployments for consistency.
+At the end, it will offer to run the web UI setup (`web/install.sh`) automatically.
+
+The SSH public key path is printed at the end — you'll need it when adding remote hosts.
 
 ---
 
-### 3. Generate the backup SSH keypair
-
-The `fsbackup` user pulls from remote hosts using the `backup` user over SSH.
-The keypair lives in the fsbackup home directory.
+### 3. Copy config files
 
 ```bash
-sudo -u fsbackup ssh-keygen -t ed25519 -f /var/lib/fsbackup/.ssh/id_ed25519_backup -N ""
-```
-
-The public key (`id_ed25519_backup.pub`) is installed on each remote source host.
-See [adding-hosts-and-targets.md](adding-hosts-and-targets.md) for that process.
-
----
-
-### 4. Create the config directory
-
-```bash
-sudo mkdir -p /etc/fsbackup/db
 sudo cp /home/<user>/fsbackup/conf/fsbackup.conf.example /etc/fsbackup/fsbackup.conf
 sudo cp /home/<user>/fsbackup/conf/targets.yml.example /etc/fsbackup/targets.yml
 sudo cp /home/<user>/fsbackup/conf/fsbackup.crontab /etc/fsbackup/fsbackup.crontab
@@ -78,44 +66,13 @@ MIRROR_SKIP_CLASSES="class3"
 
 ---
 
-### 5. Create snapshot directories
+### 4. Create mirror snapshot directory
+
+If you have a second backup drive, create its snapshot root:
 
 ```bash
-sudo mkdir -p /backup/snapshots/{daily,weekly,monthly,annual}
-sudo mkdir -p /backup2/snapshots/{daily,weekly,monthly,annual}
-sudo chown -R fsbackup:fsbackup /backup/snapshots
+sudo mkdir -p /backup2/snapshots
 sudo chown -R fsbackup:fsbackup /backup2/snapshots
-```
-
----
-
-### 6. Create log directory
-
-```bash
-sudo mkdir -p /var/lib/fsbackup/log
-sudo chown -R fsbackup:fsbackup /var/lib/fsbackup
-```
-
----
-
-### 7. Set up node_exporter textfile collector (optional)
-
-If you're running Prometheus node_exporter with the textfile collector:
-
-```bash
-sudo groupadd nodeexp_txt
-sudo usermod -aG nodeexp_txt fsbackup
-sudo usermod -aG nodeexp_txt node_exporter   # or whatever user runs node_exporter
-
-sudo mkdir -p /var/lib/node_exporter/textfile_collector
-sudo chown root:nodeexp_txt /var/lib/node_exporter/textfile_collector
-sudo chmod 2775 /var/lib/node_exporter/textfile_collector
-```
-
-Or use the repair utility, which handles all of the above and sets default ACLs:
-
-```bash
-sudo /home/<user>/fsbackup/utils/fs-nodeexp-fix.sh
 ```
 
 ---
@@ -174,24 +131,24 @@ For local targets, no key trust is needed — rsync accesses paths directly.
 
 ---
 
-### 10. Install systemd units
+### 10. Enable the scheduler
+
+The supercronic scheduler and its systemd service unit (`fsbackup-scheduler.service`) are
+set up by `web/install.sh` (which `install.sh` offered to run in step 2). If you ran it
+and answered yes to the scheduler prompt, enable and start the service:
 
 ```bash
-sudo cp /home/<user>/fsbackup/systemd/*.service /etc/systemd/system/
-sudo cp /home/<user>/fsbackup/systemd/*.timer /etc/systemd/system/
+sudo systemctl enable --now fsbackup-scheduler.service
+```
+
+If you skipped the web UI setup, run `web/install.sh` now and answer yes to the scheduler
+prompt, or install supercronic manually and deploy the crontab:
+
+```bash
+sudo cp /home/<user>/fsbackup/conf/fsbackup.crontab /etc/fsbackup/fsbackup.crontab
+sudo cp /home/<user>/fsbackup/systemd/fsbackup-scheduler.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable --now \
-  fsbackup-doctor@class1.timer \
-  fsbackup-doctor@class2.timer \
-  fsbackup-runner@class1.timer \
-  fsbackup-runner@class2.timer \
-  fsbackup-mirror-daily.timer \
-  fsbackup-mirror-promote.timer \
-  fsbackup-retention.timer \
-  fsbackup-mirror-retention.timer \
-  fsbackup-promote.timer \
-  fsbackup-s3-export.timer \
-  fsbackup-annual-promote.timer
+sudo systemctl enable --now fsbackup-scheduler.service
 ```
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # =============================================================================
-# fsbackup_bootstrap.sh
+# install.sh
 #
-# Idempotent bootstrap + updater for fsbackup system.
+# Idempotent bootstrap + installer for fsbackup system.
 # Safe to re-run at any time.
 #
 # Usage:
-#   fsbackup_bootstrap.sh [--update]
+#   install.sh [--update]
 #     [--backup-root /backup]
 # =============================================================================
 
@@ -210,4 +210,14 @@ echo "SSH public key to install on source hosts:"
 echo "  ${SSH_KEY_PATH}.pub"
 echo
 echo "Safe to re-run at any time."
+echo
+
+# -----------------------------
+# Optional: web UI setup
+# -----------------------------
+read -rp "Set up the web UI now? [y/N]: " INSTALL_WEB
+INSTALL_WEB="${INSTALL_WEB:-N}"
+if [[ "${INSTALL_WEB,,}" == "y" ]]; then
+  bash "${BOOTSTRAP_DIR}/web/install.sh"
+fi
 

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -35,7 +35,7 @@
     <div class="text-center mb-8">
       <img src="/static/logo-light.svg" alt="fsbackup" class="block dark:hidden h-32 w-auto mx-auto mb-4 rounded-lg shadow-sm"/>
       <img src="/static/logo-dark.svg"  alt="fsbackup" class="hidden dark:block h-32 w-auto mx-auto mb-4 rounded-lg shadow-sm"/>
-      <p class="text-sm text-zinc-500 mt-1">Sign in with your system account</p>
+      <p class="text-sm text-zinc-500 mt-1">Enter your configured credentials</p>
     </div>
 
     <!-- Card -->


### PR DESCRIPTION
…in text

- Rename setup.sh → install.sh (bootstrap/installer for bare-metal)
- Add "Set up the web UI now?" prompt at end of install.sh that calls web/install.sh
- Update header comment to match new filename
- docs/installation.md: replace manual steps 2–7 with install.sh; update bare-metal scheduler from "systemd timers" to "supercronic"; rewrite step 10 for fsbackup-scheduler.service
- web/templates/login.html: change "Sign in with your system account" to "Enter your configured credentials"