### PR TITLE
Add TZ environment variable to Docker compose files and docs

### DIFF
--- a/conf/docker-compose.yml.example
+++ b/conf/docker-compose.yml.example
@@ -17,6 +17,11 @@ services:
       # Container always binds on 8080 (set HOST=0.0.0.0, PORT=8080 in web/.env)
       - "8080:8080"
 
+    environment:
+      # Set to your local timezone so supercronic crontab times match wall clock.
+      # Without this the container runs UTC and cron schedule times will be offset.
+      - TZ=America/Denver
+
     env_file:
       # Copy web/.env.example → web/.env and fill in your values before starting.
       - web/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     user: "993:993"
     ports:
       - "8080:8080"
+    environment:
+      - TZ=America/Denver
+
     env_file:
       - web/.env
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -153,6 +153,10 @@ services:
     ports:
       - "172.30.3.130:8080:8080"
 
+    # Set to your local timezone so crontab times match wall clock.
+    environment:
+      - TZ=America/Denver
+
     # Web UI config and credentials (see Web UI Configuration below).
     env_file:
       - stack.env
@@ -295,6 +299,8 @@ Changes write through to the host bind mount immediately.
 ## Scheduler (Crontab)
 
 supercronic reads `/etc/fsbackup/fsbackup.crontab` at startup and hot-reloads it on change. The file is bind-mounted from the host, so you can edit it on the host and supercronic picks up the change without a container restart.
+
+> **Timezone:** The container defaults to UTC. Crontab times are interpreted in the container timezone. Set `TZ=America/Denver` (or your local timezone) in the `environment:` section of the compose file so schedule times match your local wall clock. Without this, a crontab entry of `45 1 * * *` will fire at 1:45 AM UTC, not 1:45 AM local time.
 
 The default schedule (`conf/fsbackup.crontab`):
 


### PR DESCRIPTION
Container defaults to UTC, causing supercronic to interpret crontab times as UTC rather than local time. Jobs scheduled for 01:45 local would fire at 01:45 UTC (7:45 PM MDT), shifting the entire backup window to evening instead of early morning.

Set TZ=America/Denver in the environment block so cron schedule times match wall clock. Updated docker-compose.yml, conf/docker-compose.yml.example, and docs/docker.md with the fix and an explanatory note in the Scheduler section.