### PR TITLE
fix: clarify rename modal wipe mode label

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -1051,7 +1051,8 @@ async def api_rename_target(
                 }
             threading.Thread(target=_stream_job, args=(key, proc), daemon=True).start()
             result_ok  = True
-            result_msg = f"Started rename: {from_id} → {to_id} ({mode}{'  dry-run' if dry_run == '1' else ''})"
+            mode_label = "move" if mode == "move" else "wipe history"
+            result_msg = f"Started: {from_id} → {to_id} ({mode_label}{'  dry-run' if dry_run == '1' else ''})"
         except Exception as e:
             result_msg = str(e)
 

--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -143,7 +143,7 @@
   [--dry-run]</pre>
     <div class="mt-2 space-y-0.5 text-xs text-zinc-400">
       <p><code class="font-mono">--move</code> — rename the directory in place (keeps snapshot history)</p>
-      <p><code class="font-mono">--delete</code> — remove the old target's snapshot directories</p>
+      <p><code class="font-mono">--delete</code> — wipe all snapshot directories for that target across every tier</p>
       <p><code class="font-mono">--dry-run</code> — preview changes without modifying anything</p>
     </div>
   </div>
@@ -274,7 +274,7 @@
             <input type="radio" name="mode" value="move" checked class="accent-brand-600"> Move (keep history)
           </label>
           <label class="flex items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300 cursor-pointer">
-            <input type="radio" name="mode" value="delete" class="accent-brand-600"> Delete old snapshots
+            <input type="radio" name="mode" value="delete" class="accent-brand-600"> Wipe target history
           </label>
         </div>
       </div>


### PR DESCRIPTION
Renames the \"Delete old snapshots\" radio option to **\"Wipe target history\"** in the rename target modal, and updates the CLI reference description to match.

The `--delete` mode removes all snapshot directories for a target across every tier — \"delete old snapshots\" implied only historical ones would be removed, which was misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)