### PR TITLE
fix: rename-target route shadowed by generic {action} wildcard

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -957,53 +957,6 @@ async def api_journal(request: Request, unit: str, n: int = 200):
     })
 
 
-@app.post("/api/run/{action}", response_class=HTMLResponse)
-async def api_run(request: Request, action: str, cls: str = Form(default="")):
-    """
-    Trigger a backup job. action: runner | doctor | promote | mirror
-    Spawns the script directly as a subprocess; output streamed into an
-    in-memory deque visible via the status poller. No systemd dependency.
-    """
-    key = f"{action}-{cls}" if cls else action
-    cmd = _JOB_COMMANDS.get(key)
-    result_msg = ""
-    result_ok  = False
-
-    if not cmd:
-        result_msg = f"Unknown job: {key}"
-    elif _jobs.get(key, {}).get("status") == "running":
-        result_msg = f"{key} is already running"
-    else:
-        try:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-            )
-            with _jobs_lock:
-                _jobs[key] = {
-                    "status":     "running",
-                    "rc":         None,
-                    "started_at": datetime.now(),
-                    "ended_at":   None,
-                    "lines":      deque(maxlen=20),
-                }
-            threading.Thread(target=_stream_job, args=(key, proc), daemon=True).start()
-            result_ok  = True
-            result_msg = f"Started {key}"
-        except Exception as e:
-            result_msg = str(e)
-
-    return templates.TemplateResponse("partials/run_result.html", {
-        "request":    request,
-        "result_ok":  result_ok,
-        "result_msg": result_msg,
-        "unit":       key,
-    })
-
-
 @app.post("/api/run/rename-target", response_class=HTMLResponse)
 async def api_rename_target(
     request: Request,
@@ -1053,6 +1006,53 @@ async def api_rename_target(
             result_ok  = True
             mode_label = "move" if mode == "move" else "wipe history"
             result_msg = f"Started: {from_id} → {to_id} ({mode_label}{'  dry-run' if dry_run == '1' else ''})"
+        except Exception as e:
+            result_msg = str(e)
+
+    return templates.TemplateResponse("partials/run_result.html", {
+        "request":    request,
+        "result_ok":  result_ok,
+        "result_msg": result_msg,
+        "unit":       key,
+    })
+
+
+@app.post("/api/run/{action}", response_class=HTMLResponse)
+async def api_run(request: Request, action: str, cls: str = Form(default="")):
+    """
+    Trigger a backup job. action: runner | doctor | promote | mirror
+    Spawns the script directly as a subprocess; output streamed into an
+    in-memory deque visible via the status poller. No systemd dependency.
+    """
+    key = f"{action}-{cls}" if cls else action
+    cmd = _JOB_COMMANDS.get(key)
+    result_msg = ""
+    result_ok  = False
+
+    if not cmd:
+        result_msg = f"Unknown job: {key}"
+    elif _jobs.get(key, {}).get("status") == "running":
+        result_msg = f"{key} is already running"
+    else:
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            with _jobs_lock:
+                _jobs[key] = {
+                    "status":     "running",
+                    "rc":         None,
+                    "started_at": datetime.now(),
+                    "ended_at":   None,
+                    "lines":      deque(maxlen=20),
+                }
+            threading.Thread(target=_stream_job, args=(key, proc), daemon=True).start()
+            result_ok  = True
+            result_msg = f"Started {key}"
         except Exception as e:
             result_msg = str(e)
 


### PR DESCRIPTION
## Problem

`POST /api/run/rename-target` was returning "unknown job: rename-target-class1" because FastAPI matches routes in definition order — the generic `@app.post("/api/run/{action}")` handler was defined first and captured the request with `action="rename-target"` and `cls="class1"` from the form body, constructing key `rename-target-class1` which doesn't exist in `_JOB_COMMANDS`.

## Fix

Moved `api_rename_target` to be defined before `api_run` so the specific path is registered first. Same pattern already used for `/api/run/restore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)