### PR TITLE
fix: crontab edit modal not opening on button click (#32)

### DIFF
--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -156,10 +156,7 @@
 </div>
 
 {% if crontab %}
-<div id="crontab-table"
-     hx-post="/api/config/crontab/schedule"
-     hx-target="#crontab-table"
-     hx-swap="innerHTML">
+<div id="crontab-table">
   {% include "partials/crontab_table.html" %}
 </div>
 {% else %}


### PR DESCRIPTION
## Problem

Clicking the pencil edit button on the Schedule tab did nothing — the modal never opened.

## Root cause

The `#crontab-table` div had `hx-post` set on it directly. HTMX's default trigger for non-form elements is `click`, so clicking anything inside that div (including the pencil button) immediately fired a POST to `/api/config/crontab/schedule` without any form data. This happened before the button's `onclick="openCronModal(...)"` could execute, suppressing the modal.

## Fix

Remove `hx-post`, `hx-target`, and `hx-swap` from the wrapping div — it only needs to be a swap target. The modal form carries its own `hx-post`/`hx-target`/`hx-swap` attributes and handles submission correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)