### PR TITLE
fix: crontab edit button data-* attrs to avoid onclick quoting error

### DIFF
--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -222,6 +222,10 @@ function closeCronModal() {
   document.getElementById('cron-modal').classList.add('hidden');
   document.getElementById('cron-modal').classList.remove('flex');
 }
+document.addEventListener('click', function(e) {
+  const btn = e.target.closest('.cron-edit-btn');
+  if (btn) openCronModal(btn.dataset.label, btn.dataset.command, btn.dataset.schedule);
+});
 document.addEventListener('keydown', e => { if (e.key === 'Escape') closeCronModal(); });
 </script>
 

--- a/web/templates/partials/crontab_table.html
+++ b/web/templates/partials/crontab_table.html
@@ -26,8 +26,10 @@
         <td class="px-5 py-3 font-mono text-xs text-zinc-400 dark:text-zinc-500 hidden xl:table-cell max-w-sm truncate" title="{{ entry.command }}">{{ entry.command }}</td>
         <td class="px-5 py-3 text-right">
           <button type="button"
-                  onclick="openCronModal({{ entry.label | tojson }}, {{ entry.command | tojson }}, {{ entry.schedule | tojson }})"
-                  class="text-xs text-zinc-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors"
+                  class="cron-edit-btn text-xs text-zinc-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors"
+                  data-label="{{ entry.label | e }}"
+                  data-command="{{ entry.command | e }}"
+                  data-schedule="{{ entry.schedule | e }}"
                   title="Edit schedule">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>


### PR DESCRIPTION
## Problem

Clicking the pencil edit button produced a browser console error:

```
Uncaught SyntaxError: Unexpected end of input (at configuration?tab=schedule:253:55)
```

## Root cause

The partial used `| tojson` in inline `onclick` attributes:

```html
onclick="openCronModal({{ entry.label | tojson }}, ...)"
```

Jinja2's `tojson` produces JSON with outer `"` quotes. Inside a double-quoted HTML attribute these `"` close the attribute early, producing truncated/invalid JS that the browser rejects.

## Fix

Switched to `data-label`, `data-command`, `data-schedule` attributes (HTML-escaped with `| e`) and a delegated `click` listener that reads `btn.dataset.*` — no quoting conflict possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)