### PR TITLE
fix: correct orphan metrics count and update prom on deletion

### DIFF
--- a/bin/fs-doctor.sh
+++ b/bin/fs-doctor.sh
@@ -141,7 +141,7 @@ scan_root() {
       ORPHANS["$label"]=$((ORPHANS["$label"] + 1))
       echo "$(date -Is) root=${label} tier=${tier} date=${date} class=${class} orphan=${target}" >>"$ORPHAN_LOG"
     fi
-  done < <(find "$root" -mindepth 3 -maxdepth 4 -type d)
+  done < <(find "$root" -mindepth 4 -maxdepth 4 -type d)
 }
 
 scan_root "$PRIMARY_SNAPSHOT_ROOT" "primary"

--- a/web/main.py
+++ b/web/main.py
@@ -635,6 +635,30 @@ async def api_orphans_delete(request: Request, paths: list[str] = Form(...)):
             errors.append(f"{p.name}: {e}")
 
     orphans = list_orphan_snapshots()
+
+    # Update the Prometheus orphan metric so the dashboard reflects the deletion
+    if deleted:
+        try:
+            counts: dict[str, int] = {"primary": 0, "mirror": 0}
+            for o in orphans:
+                counts[o["root"]] = counts.get(o["root"], 0) + 1
+            prom_path = PROM_DIR / "fsbackup_orphans.prom"
+            tmp = prom_path.with_suffix(".prom.tmp")
+            tmp.write_text(
+                f'fsbackup_orphan_snapshots_total{{root="primary"}} {counts["primary"]}\n'
+                f'fsbackup_orphan_snapshots_total{{root="mirror"}} {counts["mirror"]}\n'
+            )
+            try:
+                import grp
+                gid = grp.getgrnam("nodeexp_txt").gr_gid
+                os.chown(tmp, -1, gid)
+            except (KeyError, AttributeError, OSError):
+                pass
+            tmp.chmod(0o644)
+            tmp.rename(prom_path)
+        except Exception:
+            pass  # non-fatal — metric will self-correct on next doctor run
+
     return _template_response("partials/orphan_table.html", {
         "request": request,
         "orphans": orphans,


### PR DESCRIPTION
## Summary

- **`fs-doctor.sh` inflated orphan count**: `find -mindepth 3 -maxdepth 4` was scanning class directories at depth 3 (e.g. `class1`, `class2`). Since class names are not valid target IDs, every class dir across every date dir was counted as an orphan, approximately doubling the reported count. Changed to `-mindepth 4 -maxdepth 4` to only scan actual target-level directories — matching the web UI's traversal logic.

- **Prom file updated on deletion**: `/api/orphans/delete` now atomically rewrites `fsbackup_orphans.prom` after successful deletions so the Grafana dashboard reflects the correct count immediately, without waiting for the next doctor run.

## Test plan
- [ ] Deploy v1.0.9-2, trigger a doctor run — verify `fsbackup_orphan_snapshots_total` counts match the web UI list
- [ ] Delete orphans via UI — verify dashboard metric updates immediately
- [ ] Mirror orphan count in metric should now be 0 (or close) since mirror class dirs are no longer false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)