### PR TITLE
feat: fs-provision.sh, fs-restore.sh, and web UI updates for v2.0

### DIFF
--- a/bin/fs-provision.sh
+++ b/bin/fs-provision.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+# =============================================================================
+# fs-provision.sh — create ZFS datasets for all targets in targets.yml
+#
+# Reads targets.yml and creates a ZFS dataset for each target that doesn't
+# already exist. Safe to re-run — existing datasets are left untouched.
+# Must run as root (or as the fsbackup user if zfs allow is already set).
+#
+# Usage:
+#   sudo fs-provision.sh [--dry-run] [--targets-file /path/to/targets.yml]
+# =============================================================================
+
+CONFIG_FILE="/etc/fsbackup/fsbackup.conf"
+TARGETS_FILE="/etc/fsbackup/targets.yml"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)       DRY_RUN=1; shift ;;
+    --targets-file)  TARGETS_FILE="$2"; shift 2 ;;
+    *) echo "Usage: $0 [--dry-run] [--targets-file /path/to/targets.yml]"; exit 2 ;;
+  esac
+done
+
+[[ -f "$CONFIG_FILE" ]] || { echo "fsbackup.conf not found: $CONFIG_FILE"; exit 2; }
+[[ -f "$TARGETS_FILE" ]] || { echo "targets.yml not found: $TARGETS_FILE"; exit 2; }
+
+. "$CONFIG_FILE"
+PRIMARY_SNAPSHOT_ROOT="${SNAPSHOT_ROOT:-/backup/snapshots}"
+ZFS_BASE="${PRIMARY_SNAPSHOT_ROOT#/}"   # e.g. backup/snapshots
+
+for cmd in yq jq zfs; do
+  command -v "$cmd" >/dev/null || { echo "$cmd not found"; exit 2; }
+done
+
+# Verify the parent ZFS dataset exists
+if ! zfs list "$ZFS_BASE" &>/dev/null; then
+  echo "ERROR: ZFS dataset '${ZFS_BASE}' does not exist."
+  echo "       Create the pool and dataset first:"
+  echo "         zpool create -o ashift=12 backup mirror /dev/sdX /dev/sdY"
+  echo "         zfs create backup/snapshots"
+  exit 2
+fi
+
+echo
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "fs-provision.sh — DRY RUN (no datasets will be created)"
+else
+  echo "fs-provision.sh — provisioning ZFS datasets"
+fi
+echo "  ZFS base:    ${ZFS_BASE}"
+echo "  Targets:     ${TARGETS_FILE}"
+echo
+
+CREATED=0
+EXISTING=0
+FAILED=0
+
+# Iterate all target entries across all classes
+while IFS= read -r entry; do
+  id="$(jq -r '.id // empty' <<<"$entry")"
+  [[ -n "$id" ]] || continue
+
+  # Determine which class this target belongs to by extracting from yq output
+  # yq emits a comment-like marker — we use a second pass keyed on id
+  cls="$(yq eval 'to_entries | .[] | .key as $cls | .value[] | select(.id == "'"$id"'") | $cls' "$TARGETS_FILE" 2>/dev/null | head -1)"
+
+  if [[ -z "$cls" ]]; then
+    echo "  WARN  could not determine class for target: $id"
+    continue
+  fi
+
+  dataset="${ZFS_BASE}/${cls}/${id}"
+
+  if zfs list "$dataset" &>/dev/null; then
+    printf "  %-8s %-12s %s\n" "EXISTS" "[$cls]" "$dataset"
+    EXISTING=$((EXISTING + 1))
+  else
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      printf "  %-8s %-12s %s\n" "CREATE" "[$cls]" "$dataset"
+      CREATED=$((CREATED + 1))
+    else
+      if zfs create -p "$dataset"; then
+        printf "  %-8s %-12s %s\n" "CREATED" "[$cls]" "$dataset"
+        CREATED=$((CREATED + 1))
+      else
+        printf "  %-8s %-12s %s\n" "FAILED" "[$cls]" "$dataset"
+        FAILED=$((FAILED + 1))
+      fi
+    fi
+  fi
+
+done < <(yq eval -o=json '.. | select(has("id"))' "$TARGETS_FILE" | jq -c .)
+
+echo
+echo "Summary"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "  Would create: $CREATED"
+else
+  echo "  Created:  $CREATED"
+  echo "  Failed:   $FAILED"
+fi
+echo "  Existing: $EXISTING"
+echo
+
+if [[ "$FAILED" -gt 0 ]]; then
+  echo "Some datasets failed to create. Check ZFS permissions:"
+  echo "  sudo zfs allow fsbackup create,snapshot,mount,destroy ${ZFS_BASE}"
+  exit 1
+fi
+
+exit 0

--- a/utils/fs-restore.sh
+++ b/utils/fs-restore.sh
@@ -1,20 +1,46 @@
 #!/usr/bin/env bash
 set -u
+set -o pipefail
+
+# =============================================================================
+# fs-restore.sh — browse and restore from ZFS snapshots (v2.0)
+#
+# Snapshot data is accessed via the hidden .zfs/snapshot/ directory which
+# ZFS exposes automatically on every dataset. No mount/unmount needed.
+#
+# Snapshot naming: <type>-<date>
+#   daily:   daily-2026-03-23
+#   weekly:  weekly-2026-W12
+#   monthly: monthly-2026-03
+#   annual:  annual-2026
+#
+# Usage:
+#   fs-restore.sh list [--type <type>] [--class <class>] [--id <id>]
+#   fs-restore.sh restore --class <class> --id <id> (--snapshot <name> | --latest [--type <type>]) --to <path>
+#   fs-restore.sh restore --class <class> --id <id> (--snapshot <name> | --latest [--type <type>]) --to-host <host> --to-path <path>
+#
+# Examples:
+#   fs-restore.sh list
+#   fs-restore.sh list --class class2
+#   fs-restore.sh list --class class2 --id nginx.data
+#   fs-restore.sh list --type weekly
+#   fs-restore.sh restore --class class2 --id nginx.data --latest --to /tmp/restore
+#   fs-restore.sh restore --class class2 --id nginx.data --snapshot weekly-2026-W12 --to /tmp/restore
+#   fs-restore.sh restore --class class1 --id ns1.bind.zones --latest --type daily --to-host ns1 --to-path /tmp/restore
+# =============================================================================
+
 . /etc/fsbackup/fsbackup.conf
+PRIMARY_SNAPSHOT_ROOT="${SNAPSHOT_ROOT:-/backup/snapshots}"
+ZFS_BASE="${PRIMARY_SNAPSHOT_ROOT#/}"
 BACKUP_SSH_USER="backup"
 
-usage() {
-  cat <<EOF
-Usage:
-  fs-restore.sh list --type <daily|weekly|monthly> [--class <class>] [--date <key>]
-  fs-restore.sh restore --type <daily|weekly|monthly> --class <class> --id <id> [--date <key>|--latest] --to <path>
-  fs-restore.sh restore --type <daily|weekly|monthly> --class <class> --id <id> [--date <key>|--latest] --to-host <host> --to-path <path>
+for cmd in zfs rsync; do
+  command -v "$cmd" >/dev/null || { echo "$cmd not found" >&2; exit 2; }
+done
 
-Examples:
-  fs-restore.sh list --type daily --class class2
-  fs-restore.sh restore --type daily --class class2 --id nginx.config --latest --to /tmp/restore-nginx
-  fs-restore.sh restore --type daily --class class2 --id bind.named.conf --date 2026-01-29 --to-host ns1 --to-path /tmp/restore-bind
-EOF
+usage() {
+  grep '^# ' "$0" | sed -n '/^# Usage:/,/^# Examples:/p' | sed 's/^# \?//'
+  exit 0
 }
 
 CMD="${1:-}"
@@ -23,7 +49,7 @@ shift || true
 TYPE=""
 CLASS=""
 ID=""
-DATE=""
+SNAPSHOT=""
 LATEST=0
 TO=""
 TO_HOST=""
@@ -31,84 +57,154 @@ TO_PATH=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --type) TYPE="$2"; shift 2 ;;
-    --class) CLASS="$2"; shift 2 ;;
-    --id) ID="$2"; shift 2 ;;
-    --date) DATE="$2"; shift 2 ;;
-    --latest) LATEST=1; shift ;;
-    --to) TO="$2"; shift 2 ;;
-    --to-host) TO_HOST="$2"; shift 2 ;;
-    --to-path) TO_PATH="$2"; shift 2 ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    --type)      TYPE="$2"; shift 2 ;;
+    --class)     CLASS="$2"; shift 2 ;;
+    --id)        ID="$2"; shift 2 ;;
+    --snapshot)  SNAPSHOT="$2"; shift 2 ;;
+    --latest)    LATEST=1; shift ;;
+    --to)        TO="$2"; shift 2 ;;
+    --to-host)   TO_HOST="$2"; shift 2 ;;
+    --to-path)   TO_PATH="$2"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
 done
 
-[[ "$TYPE" == "daily" || "$TYPE" == "weekly" || "$TYPE" == "monthly" ]] || { echo "Missing/invalid --type" >&2; exit 2; }
+if [[ -n "$TYPE" ]]; then
+  case "$TYPE" in
+    daily|weekly|monthly|annual) ;;
+    *) echo "Invalid --type: $TYPE (must be daily|weekly|monthly|annual)" >&2; exit 2 ;;
+  esac
+fi
 
-pick_latest_key() {
-  local base="${SNAPSHOT_ROOT}/${TYPE}"
-  [[ -d "$base" ]] || return 1
-  ls -1 "$base" | sort | tail -n 1
+# list_snapshots <dataset> — print snapshot names (newest first), filtered by $TYPE if set
+list_snapshots() {
+  local dataset="$1"
+  local prefix="${TYPE:+${TYPE}-}"
+  zfs list -t snapshot -r -H -o name "$dataset" 2>/dev/null \
+    | awk -F@ '{print $2}' \
+    | grep "^${prefix}" \
+    | sort -r
 }
 
-resolve_key() {
-  if [[ -n "$DATE" ]]; then
-    echo "$DATE"
-  elif [[ "$LATEST" -eq 1 ]]; then
-    pick_latest_key
-  else
-    echo "Missing --date or --latest" >&2
-    exit 2
+# resolve_snapshot <dataset> — echo the snapshot name to use for restore
+resolve_snapshot() {
+  local dataset="$1"
+  if [[ -n "$SNAPSHOT" ]]; then
+    echo "$SNAPSHOT"
+    return
   fi
+  if [[ "$LATEST" -eq 1 ]]; then
+    local snap
+    snap="$(list_snapshots "$dataset" | head -1)"
+    if [[ -z "$snap" ]]; then
+      echo "No snapshots found for ${dataset}${TYPE:+ (type=${TYPE})}" >&2
+      exit 4
+    fi
+    echo "$snap"
+    return
+  fi
+  echo "Provide --snapshot <name> or --latest" >&2
+  exit 2
 }
 
 case "$CMD" in
+# -----------------------------------------------------------------------------
   list)
-    KEY="${DATE:-}"
-    if [[ -z "$KEY" ]]; then
-      echo "Available ${TYPE} keys:"
-      ls -1 "${SNAPSHOT_ROOT}/${TYPE}" 2>/dev/null | sort || true
-      exit 0
+    if [[ -z "$CLASS" && -z "$ID" ]]; then
+      echo "Snapshots in ${ZFS_BASE}${TYPE:+ (type=${TYPE})}:"
+      printf "  %-12s %-32s %s\n" "CLASS" "TARGET" "SNAPSHOTS"
+      printf "  %-12s %-32s %s\n" "------------" "--------------------------------" "---------"
+      declare -A counts
+      while IFS= read -r line; do
+        dataset="${line%%@*}"
+        snapname="${line##*@}"
+        rel="${dataset#${ZFS_BASE}/}"
+        cls="${rel%%/*}"
+        tgt="${rel#*/}"
+        [[ "$cls" == "$tgt" || "$tgt" == */* ]] && continue
+        key="${cls}|${tgt}"
+        counts["$key"]=$(( ${counts["$key"]:-0} + 1 ))
+      done < <(zfs list -t snapshot -r -H -o name "$ZFS_BASE" 2>/dev/null \
+               | grep "@${TYPE:+${TYPE}-}" | sort)
+      for key in $(echo "${!counts[@]}" | tr ' ' '\n' | sort); do
+        cls="${key%%|*}"; tgt="${key#*|}"
+        printf "  %-12s %-32s %d\n" "$cls" "$tgt" "${counts[$key]}"
+      done
+
+    elif [[ -n "$CLASS" && -z "$ID" ]]; then
+      echo "Snapshots in ${ZFS_BASE}/${CLASS}${TYPE:+ (type=${TYPE})}:"
+      printf "  %-32s %s\n" "TARGET" "SNAPSHOTS"
+      printf "  %-32s %s\n" "--------------------------------" "---------"
+      declare -A counts
+      while IFS= read -r line; do
+        dataset="${line%%@*}"
+        rel="${dataset#${ZFS_BASE}/}"
+        cls="${rel%%/*}"
+        tgt="${rel#*/}"
+        [[ "$cls" != "$CLASS" || "$tgt" == */* ]] && continue
+        counts["$tgt"]=$(( ${counts["$tgt"]:-0} + 1 ))
+      done < <(zfs list -t snapshot -r -H -o name "${ZFS_BASE}/${CLASS}" 2>/dev/null \
+               | grep "@${TYPE:+${TYPE}-}" | sort)
+      for tgt in $(echo "${!counts[@]}" | tr ' ' '\n' | sort); do
+        printf "  %-32s %d\n" "$tgt" "${counts[$tgt]}"
+      done
+
+    else
+      [[ -n "$CLASS" && -n "$ID" ]] || { echo "list: provide --class and --id for target-level listing" >&2; exit 2; }
+      dataset="${ZFS_BASE}/${CLASS}/${ID}"
+      echo "Snapshots for ${CLASS}/${ID}${TYPE:+ (type=${TYPE})}:"
+      snaps="$(list_snapshots "$dataset")"
+      if [[ -z "$snaps" ]]; then
+        echo "  (none)"
+      else
+        while IFS= read -r s; do echo "  ${s}"; done <<<"$snaps"
+      fi
     fi
-    if [[ -z "$CLASS" ]]; then
-      echo "Classes under ${TYPE}/${KEY}:"
-      ls -1 "${SNAPSHOT_ROOT}/${TYPE}/${KEY}" 2>/dev/null | sort || true
-      exit 0
-    fi
-    echo "Targets under ${TYPE}/${KEY}/${CLASS}:"
-    ls -1 "${SNAPSHOT_ROOT}/${TYPE}/${KEY}/${CLASS}" 2>/dev/null | sort || true
     ;;
 
+# -----------------------------------------------------------------------------
   restore)
-    [[ -n "$CLASS" && -n "$ID" ]] || { echo "restore requires --class and --id" >&2; exit 2; }
-    [[ -n "$DATE" || "$LATEST" -eq 1 ]] || { echo "restore requires --date or --latest" >&2; exit 2; }
-    KEY="$(resolve_key)"
+    [[ -n "$CLASS" ]] || { echo "restore requires --class" >&2; exit 2; }
+    [[ -n "$ID" ]]    || { echo "restore requires --id" >&2; exit 2; }
+    [[ -n "$TO" || ( -n "$TO_HOST" && -n "$TO_PATH" ) ]] \
+      || { echo "restore requires --to or (--to-host and --to-path)" >&2; exit 2; }
 
-    SRC="${SNAPSHOT_ROOT}/${TYPE}/${KEY}/${CLASS}/${ID}"
-    [[ -d "$SRC" ]] || { echo "Snapshot not found: $SRC" >&2; exit 4; }
+    dataset="${ZFS_BASE}/${CLASS}/${ID}"
+    zfs list "$dataset" &>/dev/null || { echo "Dataset not found: $dataset" >&2; exit 4; }
+
+    snap="$(resolve_snapshot "$dataset")"
+    snap_data="${PRIMARY_SNAPSHOT_ROOT}/${CLASS}/${ID}/.zfs/snapshot/${snap}"
+
+    if [[ ! -d "$snap_data" ]]; then
+      echo "Snapshot data not found: $snap_data" >&2
+      echo "Available snapshots:"
+      list_snapshots "$dataset" | sed 's/^/  /'
+      exit 4
+    fi
+
+    echo "Source:  ${CLASS}/${ID}@${snap}"
+    echo "Data:    ${snap_data}"
 
     if [[ -n "$TO" ]]; then
       mkdir -p "$TO"
-      rsync -a "$SRC/" "$TO/"
-      echo "Restored to: $TO"
+      rsync -a --info=progress2 "${snap_data}/" "${TO}/"
+      echo "Restored to: ${TO}"
       exit 0
     fi
 
-    if [[ -n "$TO_HOST" && -n "$TO_PATH" ]]; then
-      ssh "${BACKUP_SSH_USER}@${TO_HOST}" "mkdir -p '$TO_PATH'" >/dev/null
-      rsync -a "$SRC/" "${BACKUP_SSH_USER}@${TO_HOST}:${TO_PATH%/}/"
-      echo "Restored to: ${TO_HOST}:${TO_PATH}"
-      exit 0
-    fi
+    ssh "${BACKUP_SSH_USER}@${TO_HOST}" "mkdir -p '${TO_PATH}'"
+    rsync -a --info=progress2 "${snap_data}/" "${BACKUP_SSH_USER}@${TO_HOST}:${TO_PATH%/}/"
+    echo "Restored to: ${TO_HOST}:${TO_PATH}"
+    ;;
 
-    echo "restore requires either --to or (--to-host and --to-path)" >&2
-    exit 2
+# -----------------------------------------------------------------------------
+  -h|--help|"")
+    usage
     ;;
 
   *)
+    echo "Unknown command: ${CMD}" >&2
     usage
-    exit 2
     ;;
 esac
-

--- a/web/main.py
+++ b/web/main.py
@@ -29,7 +29,6 @@ from starlette.middleware.sessions import SessionMiddleware
 # ---------------------------------------------------------------------------
 
 SNAPSHOT_ROOT = Path(os.environ.get("SNAPSHOT_ROOT", "/backup/snapshots"))
-MIRROR_ROOT   = Path(os.environ.get("MIRROR_ROOT",   "/backup2/snapshots"))
 TARGETS_FILE  = Path(os.environ.get("TARGETS_FILE",  "/etc/fsbackup/targets.yml"))
 SCRIPTS_DIR   = Path(os.environ.get("SCRIPTS_DIR",   "/opt/fsbackup"))
 CRONTAB_FILE  = Path(os.environ.get("CRONTAB_FILE",  "/etc/fsbackup/fsbackup.crontab"))
@@ -130,54 +129,69 @@ def expiration_date(tier: str, snapshot_date: date | None) -> date | None:
     return snapshot_date + timedelta(days=days)
 
 
-def snapshot_is_mirrored(tier: str, date_str: str, cls: str, target: str) -> bool:
-    mirror_path = MIRROR_ROOT / tier / date_str / cls / target
-    return mirror_path.exists()
-
-
 def list_snapshots(tier_filter=None, class_filter=None, target_filter=None, date_filter=None) -> list[dict]:
-    """Walk SNAPSHOT_ROOT and return a list of snapshot dicts."""
+    """Enumerate ZFS snapshots and return a list of snapshot dicts (v2.0).
+
+    Snapshots are named <type>-<date> (e.g. daily-2026-03-23, weekly-2026-W12).
+    Data is accessed via the .zfs/snapshot/ hidden directory on each dataset.
+    """
     snapshots = []
     today = date.today()
+    zfs_base = str(SNAPSHOT_ROOT).lstrip("/")
 
-    tiers = [tier_filter] if tier_filter else TIERS
-    for tier in tiers:
-        tier_path = SNAPSHOT_ROOT / tier
-        if not tier_path.is_dir():
+    try:
+        result = subprocess.run(
+            ["zfs", "list", "-t", "snapshot", "-r", "-H", "-o", "name", zfs_base],
+            capture_output=True, text=True, timeout=10,
+        )
+        lines = result.stdout.strip().splitlines()
+    except Exception:
+        return []
+
+    for line in sorted(lines, reverse=True):
+        if "@" not in line:
             continue
-        for date_dir in sorted(tier_path.iterdir(), reverse=True):
-            if not date_dir.is_dir():
-                continue
-            if date_filter and date_dir.name != date_filter:
-                continue
-            snap_date = parse_snapshot_date(tier, date_dir.name)
-            exp_date  = expiration_date(tier, snap_date)
-            expires_soon = (
-                exp_date is not None and (exp_date - today).days <= 3
-            ) if exp_date else False
+        dataset, snapname = line.split("@", 1)
+        rel = dataset.removeprefix(zfs_base + "/")
+        if "/" not in rel:
+            continue  # the base dataset itself
+        cls, target = rel.split("/", 1)
+        if "/" in target:
+            continue  # unexpected depth
 
-            for cls_dir in sorted(date_dir.iterdir()):
-                if not cls_dir.is_dir():
-                    continue
-                if class_filter and cls_dir.name != class_filter:
-                    continue
-                for target_dir in sorted(cls_dir.iterdir()):
-                    if not target_dir.is_dir():
-                        continue
-                    if target_filter and target_dir.name != target_filter:
-                        continue
-                    mirrored = snapshot_is_mirrored(tier, date_dir.name, cls_dir.name, target_dir.name)
-                    snapshots.append({
-                        "tier":         tier,
-                        "date":         date_dir.name,
-                        "class":        cls_dir.name,
-                        "target":       target_dir.name,
-                        "path":         str(target_dir),
-                        "snap_date":    snap_date,
-                        "exp_date":     exp_date,
-                        "expires_soon": expires_soon,
-                        "mirrored":     mirrored,
-                    })
+        if "-" not in snapname:
+            continue
+        tier, _, date_str = snapname.partition("-")
+        if tier not in TIERS:
+            continue
+
+        if tier_filter and tier != tier_filter:
+            continue
+        if class_filter and cls != class_filter:
+            continue
+        if target_filter and target != target_filter:
+            continue
+        if date_filter and date_str != date_filter:
+            continue
+
+        snap_date = parse_snapshot_date(tier, date_str)
+        exp_date  = expiration_date(tier, snap_date)
+        expires_soon = (
+            exp_date is not None and (exp_date - today).days <= 3
+        ) if exp_date else False
+
+        snap_data = SNAPSHOT_ROOT / cls / target / ".zfs" / "snapshot" / snapname
+        snapshots.append({
+            "tier":         tier,
+            "date":         date_str,
+            "class":        cls,
+            "target":       target,
+            "snapshot":     snapname,
+            "path":         str(snap_data),
+            "snap_date":    snap_date,
+            "exp_date":     exp_date,
+            "expires_soon": expires_soon,
+        })
     return snapshots
 
 
@@ -343,12 +357,11 @@ async def snapshots_page(
     )
     # Unique values for filter dropdowns
     all_targets = sorted({s["target"] for s in list_snapshots()})
-    # Available dates for selected tier (for the date picker datalist)
-    tier_dates = []
-    if tier:
-        tier_path = SNAPSHOT_ROOT / tier
-        if tier_path.is_dir():
-            tier_dates = sorted([d.name for d in tier_path.iterdir() if d.is_dir()], reverse=True)
+    # Available dates for the selected tier (for the date picker datalist)
+    tier_dates = sorted(
+        {s["date"] for s in list_snapshots(tier_filter=tier or None)},
+        reverse=True,
+    ) if tier else []
 
     return templates.TemplateResponse("snapshots.html", {
         "request":       request,
@@ -508,14 +521,11 @@ async def api_restore(
         error = "Destination path is required."
     else:
         snap = Path(snapshot_path)
-        # Safety: must be within a known snapshot root
-        allowed_roots = [SNAPSHOT_ROOT]
-        if MIRROR_ROOT:
-            allowed_roots.append(MIRROR_ROOT)
+        # Safety: must be within SNAPSHOT_ROOT
         try:
             resolved = snap.resolve()
-            if not any(str(resolved).startswith(str(r)) for r in allowed_roots):
-                error = f"Snapshot path must be within {SNAPSHOT_ROOT} or {MIRROR_ROOT}"
+            if not str(resolved).startswith(str(SNAPSHOT_ROOT)):
+                error = f"Snapshot path must be within {SNAPSHOT_ROOT}"
             elif not resolved.is_dir():
                 error = f"Snapshot directory not found: {snapshot_path}"
         except Exception as e:
@@ -809,36 +819,17 @@ async def configuration_page(request: Request, tab: str = "hosts"):
                 seen.add(h)
                 hosts.append(h)
 
-    # Build per-target volume info: which snapshot root has data for it?
-    target_volumes: dict[str, list[str]] = {}
-    for class_targets in targets.values():
+    # Build per-target provisioned status: does the ZFS dataset exist?
+    target_volumes: dict[str, bool] = {}
+    for class_name, class_targets in targets.items():
         for t in class_targets:
             tid = t.get("id", "")
-            vols = []
-            for root in (SNAPSHOT_ROOT, MIRROR_ROOT):
-                for tier_dir in root.glob("*"):
-                    for date_dir in tier_dir.glob("*"):
-                        for cls_dir in date_dir.glob("*"):
-                            if (cls_dir / tid).exists():
-                                vols.append(str(root))
-                                break
-                        else:
-                            continue
-                        break
-                    else:
-                        continue
-                    break
-            target_volumes[tid] = list(set(vols))
+            target_volumes[tid] = (SNAPSHOT_ROOT / class_name / tid).is_dir()
 
     primary_disk = _disk_info(SNAPSHOT_ROOT)
-    mirror_disk  = _disk_info(MIRROR_ROOT)
-
     primary_disk["fmt_used"]  = _fmt_bytes(primary_disk["used"])
     primary_disk["fmt_free"]  = _fmt_bytes(primary_disk["free"])
     primary_disk["fmt_total"] = _fmt_bytes(primary_disk["total"])
-    mirror_disk["fmt_used"]   = _fmt_bytes(mirror_disk["used"])
-    mirror_disk["fmt_free"]   = _fmt_bytes(mirror_disk["free"])
-    mirror_disk["fmt_total"]  = _fmt_bytes(mirror_disk["total"])
 
     crontab = _load_crontab()
 
@@ -849,10 +840,8 @@ async def configuration_page(request: Request, tab: str = "hosts"):
         "targets":        targets,
         "target_volumes": target_volumes,
         "primary_disk":   primary_disk,
-        "mirror_disk":    mirror_disk,
         "crontab":        crontab,
         "snapshot_root":  str(SNAPSHOT_ROOT),
-        "mirror_root":    str(MIRROR_ROOT),
     })
 
 
@@ -1002,10 +991,10 @@ async def api_snapshots(
 @app.get("/api/tier-dates", response_class=HTMLResponse)
 async def api_tier_dates(request: Request, tier: str = "daily"):
     """Return a datalist of available dates for a given tier (for the date picker)."""
-    dates = []
-    tier_path = SNAPSHOT_ROOT / tier
-    if tier_path.is_dir():
-        dates = sorted([d.name for d in tier_path.iterdir() if d.is_dir()], reverse=True)
+    dates = sorted(
+        {s["date"] for s in list_snapshots(tier_filter=tier or None)},
+        reverse=True,
+    )
     options = "".join(f'<option value="{d}"></option>' for d in dates)
     return HTMLResponse(f'<datalist id="tier-dates">{options}</datalist>')
 

--- a/web/templates/browse.html
+++ b/web/templates/browse.html
@@ -13,7 +13,7 @@
     <div class="flex-1">
       <label class="block text-xs text-zinc-500 mb-1">Snapshot path</label>
       <input type="text" name="path" value="{{ current_path }}"
-             placeholder="{{ snapshot_root }}/daily/2025-01-01/class1/myhost.myapp"
+             placeholder="{{ snapshot_root }}/class1/myhost.myapp/.zfs/snapshot/daily-2026-03-23"
              class="w-full bg-zinc-50 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 text-zinc-900 dark:text-zinc-100 text-sm font-mono rounded-lg px-3 py-2 focus:outline-none focus:border-brand-500"/>
     </div>
     <button type="submit"

--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -233,42 +233,27 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeCronMod
 {% elif tab == "volumes" %}
 <div class="space-y-6">
 
-  <!-- Volume status cards -->
+  <!-- Volume status card -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-    {% for disk, label in [(primary_disk, "Primary — " ~ snapshot_root), (mirror_disk, "Mirror — " ~ mirror_root)] %}
     <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm">
-      <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">{{ label }}</p>
-      {% if disk.error %}
-      <p class="text-sm text-red-500">{{ disk.error }}</p>
+      <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">ZFS pool — {{ snapshot_root }}</p>
+      {% if primary_disk.error %}
+      <p class="text-sm text-red-500">{{ primary_disk.error }}</p>
       {% else %}
       <div class="flex items-end justify-between mb-2">
-        <span class="text-2xl font-bold text-zinc-900 dark:text-white">{{ disk.fmt_used }}</span>
-        <span class="text-xs text-zinc-400">of {{ disk.fmt_total }}</span>
+        <span class="text-2xl font-bold text-zinc-900 dark:text-white">{{ primary_disk.fmt_used }}</span>
+        <span class="text-xs text-zinc-400">of {{ primary_disk.fmt_total }}</span>
       </div>
       <div class="w-full bg-zinc-100 dark:bg-zinc-800 rounded-full h-2 mb-2">
-        <div class="h-2 rounded-full {% if disk.pct_used > 85 %}bg-red-500{% elif disk.pct_used > 70 %}bg-amber-500{% else %}bg-brand-500{% endif %}"
-             style="width: {{ disk.pct_used }}%"></div>
+        <div class="h-2 rounded-full {% if primary_disk.pct_used > 85 %}bg-red-500{% elif primary_disk.pct_used > 70 %}bg-amber-500{% else %}bg-brand-500{% endif %}"
+             style="width: {{ primary_disk.pct_used }}%"></div>
       </div>
       <div class="flex justify-between text-xs text-zinc-400">
-        <span>{{ disk.pct_used }}% used</span>
-        <span>{{ disk.fmt_free }} free</span>
+        <span>{{ primary_disk.pct_used }}% used</span>
+        <span>{{ primary_disk.fmt_free }} free</span>
       </div>
       {% endif %}
     </div>
-    {% endfor %}
-  </div>
-
-  <!-- Annual mirror check -->
-  <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm">
-    <div class="flex items-start justify-between mb-3">
-      <div>
-        <p class="text-sm font-semibold text-zinc-800 dark:text-zinc-200">Annual Mirror Check</p>
-        <p class="text-xs text-zinc-500 mt-0.5">Verify that annual snapshots on the primary drive are present and matching on the mirror. Run this after the January 5 annual promotion.</p>
-      </div>
-      <span class="text-xs font-mono text-zinc-400 dark:text-zinc-500 shrink-0 ml-4">utils/fs-annual-mirror-check.sh</span>
-    </div>
-    <pre class="text-xs font-mono bg-zinc-50 dark:bg-zinc-950 text-zinc-700 dark:text-zinc-300 rounded-lg p-3 overflow-x-auto">sudo -u fsbackup /opt/fsbackup/utils/fs-annual-mirror-check.sh</pre>
-    <p class="text-xs text-zinc-400 mt-2">Compares byte counts between <code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded">/backup/snapshots/annual</code> and <code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded">/backup2/snapshots/annual</code> and emits a Prometheus metric.</p>
   </div>
 
   <!-- Node exporter troubleshooting -->

--- a/web/templates/partials/snapshot_rows.html
+++ b/web/templates/partials/snapshot_rows.html
@@ -14,18 +14,6 @@
   <td class="px-4 py-2.5 font-mono text-zinc-600 dark:text-zinc-300 text-xs">{{ s.date }}</td>
   <td class="px-4 py-2.5 text-zinc-500 text-xs">{{ s.class }}</td>
   <td class="px-4 py-2.5 font-medium text-zinc-900 dark:text-white">{{ s.target }}</td>
-  <td class="px-4 py-2.5">
-    {% if s.mirrored %}
-      <span class="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
-        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-        </svg>
-        Yes
-      </span>
-    {% else %}
-      <span class="text-xs text-zinc-300 dark:text-zinc-600">—</span>
-    {% endif %}
-  </td>
   <td class="px-4 py-2.5 text-xs">
     {% if s.exp_date is none %}
       <span class="text-zinc-400">Never</span>
@@ -46,6 +34,6 @@
 </tr>
 {% else %}
 <tr>
-  <td colspan="7" class="px-4 py-8 text-center text-zinc-400 text-sm">No snapshots found.</td>
+  <td colspan="6" class="px-4 py-8 text-center text-zinc-400 text-sm">No snapshots found.</td>
 </tr>
 {% endfor %}

--- a/web/templates/restore.html
+++ b/web/templates/restore.html
@@ -18,7 +18,7 @@
       <div>
         <label class="block text-xs text-zinc-500 mb-1">Snapshot path</label>
         <input type="text" name="snapshot_path" value="{{ snapshot_path }}"
-               placeholder="/backup/snapshots/daily/2025-01-01/class1/myhost.myapp"
+               placeholder="/backup/snapshots/class1/myhost.myapp/.zfs/snapshot/daily-2026-03-23"
                class="w-full bg-zinc-50 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 text-zinc-900 dark:text-zinc-100 text-sm font-mono rounded-lg px-3 py-2 focus:outline-none focus:border-brand-500"/>
         <p class="text-xs text-zinc-400 mt-1">Full path to the snapshot directory</p>
       </div>
@@ -74,7 +74,8 @@
 <div class="mt-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm">
   <h2 class="text-sm font-semibold text-zinc-700 dark:text-zinc-300 mb-2">Manual restore</h2>
   <p class="text-xs text-zinc-400 mb-3">To restore from the command line:</p>
-  <pre class="text-xs text-zinc-700 dark:text-zinc-300 font-mono bg-zinc-50 dark:bg-zinc-950 rounded-lg p-4 overflow-x-auto">/opt/fsbackup/utils/fs-restore.sh --snapshot /backup/snapshots/&lt;tier&gt;/&lt;date&gt;/&lt;class&gt;/&lt;target&gt; --dest /restore/path</pre>
+  <pre class="text-xs text-zinc-700 dark:text-zinc-300 font-mono bg-zinc-50 dark:bg-zinc-950 rounded-lg p-4 overflow-x-auto">/opt/fsbackup/utils/fs-restore.sh restore --class &lt;class&gt; --id &lt;target&gt; --latest --to /restore/path
+/opt/fsbackup/utils/fs-restore.sh restore --class &lt;class&gt; --id &lt;target&gt; --snapshot weekly-2026-W12 --to /restore/path</pre>
   <p class="text-xs text-zinc-400 mt-4">For S3 archives:</p>
   <pre class="text-xs text-zinc-700 dark:text-zinc-300 font-mono bg-zinc-50 dark:bg-zinc-950 rounded-lg p-4 mt-1 overflow-x-auto">aws s3 cp s3://fsbackup-snapshots-SUFFIX/&lt;tier&gt;/&lt;class&gt;/&lt;target&gt;/&lt;archive&gt;.tar.zst.age . \
   &amp;&amp; age -d -i /etc/fsbackup/age.key &lt;archive&gt;.tar.zst.age | zstd -d | tar -xf - -C /restore/path/</pre>

--- a/web/templates/snapshots.html
+++ b/web/templates/snapshots.html
@@ -85,7 +85,6 @@
         <th class="px-4 py-3 font-medium">Date</th>
         <th class="px-4 py-3 font-medium">Class</th>
         <th class="px-4 py-3 font-medium">Target</th>
-        <th class="px-4 py-3 font-medium">Mirrored</th>
         <th class="px-4 py-3 font-medium">Expires</th>
         <th class="px-4 py-3 font-medium"></th>
       </tr>


### PR DESCRIPTION
## Summary

- **fs-provision.sh**: new script to create ZFS datasets from `targets.yml`. Idempotent, `--dry-run` support, reports created/existing/failed per target.
- **fs-restore.sh**: rewritten for v2.0 flat ZFS structure. New `list` and `restore` subcommands; reads snapshot data from `.zfs/snapshot/<name>/`; supports `--latest [--type]` or `--snapshot <name>`.
- **web/main.py**: remove `MIRROR_ROOT`; rewrite `list_snapshots()` to enumerate via `zfs list -t snapshot`; fix snapshot browser, tier-date datalist, restore safety check, and configuration page.
- **Templates**: remove Mirrored column from snapshot table; update restore/browse placeholders and CLI examples; simplify volumes tab to single ZFS pool card.

## Test plan
- [x] Deploy to `/opt/fsbackup` and restart `fsbackup-web`
- [x] Snapshots page loads and shows ZFS snapshots with correct tier/date/class/target
- [x] Tier filter + date datalist populate correctly from ZFS
- [x] Browse link navigates into `.zfs/snapshot/<name>/`
- [x] Restore quick-select populates snapshot path field; dry-run works
- [x] Configuration > Volumes tab shows ZFS pool disk usage
- [x] `fs-provision.sh --dry-run` lists expected datasets
- [x] `fs-restore.sh list` shows available snapshots
- [x] `fs-restore.sh restore --class class2 --id nginx.data --latest --to /tmp/test` restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)