### PR TITLE
fix: ZFS-accurate disk usage; per-target dataset size in Targets tab

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -785,7 +785,25 @@ def _load_crontab() -> list[dict]:
 
 
 def _disk_info(path: Path) -> dict:
-    """Return df-style info for a path: total, used, free (bytes), and pct_used."""
+    """Return df-style info for a path: total, used, free (bytes), and pct_used.
+
+    For ZFS paths, uses `zfs list -Hp -o used,avail` which returns accurate
+    pool-level stats. Falls back to statvfs for non-ZFS paths.
+    """
+    zfs_base = str(path).lstrip("/")
+    try:
+        r = subprocess.run(
+            ["zfs", "list", "-Hp", "-o", "used,avail", zfs_base],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0:
+            parts = r.stdout.strip().split()
+            used, free = int(parts[0]), int(parts[1])
+            total = used + free
+            pct   = round(used / total * 100) if total else 0
+            return {"path": str(path), "total": total, "used": used, "free": free, "pct_used": pct, "error": None}
+    except Exception:
+        pass
     try:
         st = os.statvfs(path)
         total = st.f_blocks * st.f_frsize
@@ -819,12 +837,28 @@ async def configuration_page(request: Request, tab: str = "hosts"):
                 seen.add(h)
                 hosts.append(h)
 
-    # Build per-target provisioned status: does the ZFS dataset exist?
-    target_volumes: dict[str, bool] = {}
+    # Build per-target ZFS dataset size (used bytes, including snapshots).
+    # One `zfs list` call for all datasets under SNAPSHOT_ROOT.
+    zfs_base = str(SNAPSHOT_ROOT).lstrip("/")
+    dataset_used: dict[str, int] = {}
+    try:
+        r = subprocess.run(
+            ["zfs", "list", "-rHp", "-o", "name,used", zfs_base],
+            capture_output=True, text=True, timeout=10,
+        )
+        for line in r.stdout.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) == 2:
+                dataset_used[parts[0]] = int(parts[1])
+    except Exception:
+        pass
+
+    target_volumes: dict[str, int | None] = {}
     for class_name, class_targets in targets.items():
         for t in class_targets:
             tid = t.get("id", "")
-            target_volumes[tid] = (SNAPSHOT_ROOT / class_name / tid).is_dir()
+            key = f"{zfs_base}/{class_name}/{tid}"
+            target_volumes[tid] = dataset_used.get(key)
 
     primary_disk = _disk_info(SNAPSHOT_ROOT)
     primary_disk["fmt_used"]  = _fmt_bytes(primary_disk["used"])

--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -99,6 +99,7 @@
             <th class="px-4 py-3 font-medium">Host</th>
             <th class="px-4 py-3 font-medium">Source Path</th>
             <th class="px-4 py-3 font-medium">Excludes</th>
+            <th class="px-4 py-3 font-medium">Dataset Size</th>
             <th class="px-4 py-3 font-medium"></th>
           </tr>
         </thead>
@@ -110,6 +111,18 @@
             <td class="px-4 py-2.5 text-zinc-600 dark:text-zinc-300 font-mono text-xs">{{ target.source }}</td>
             <td class="px-4 py-2.5 text-xs text-zinc-400 font-mono max-w-xs truncate">
               {{ target.rsync_opts if target.rsync_opts is defined else '—' }}
+            </td>
+            <td class="px-4 py-2.5 text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+              {% set sz = target_volumes.get(target.id) %}
+              {% if sz is none %}
+                <span class="text-zinc-300 dark:text-zinc-600">not provisioned</span>
+              {% else %}
+                {% if sz < 1048576 %}{{ "%.0f KB" | format(sz / 1024) }}
+                {% elif sz < 1073741824 %}{{ "%.1f MB" | format(sz / 1048576) }}
+                {% elif sz < 1099511627776 %}{{ "%.2f GB" | format(sz / 1073741824) }}
+                {% else %}{{ "%.2f TB" | format(sz / 1099511627776) }}
+                {% endif %}
+              {% endif %}
             </td>
             <td class="px-4 py-2.5 text-right whitespace-nowrap">
               <a href="/snapshots?target={{ target.id }}"
@@ -123,7 +136,7 @@
           </tr>
           {% else %}
           <tr>
-            <td colspan="5" class="px-4 py-6 text-center text-zinc-400 text-sm">No targets defined.</td>
+            <td colspan="6" class="px-4 py-6 text-center text-zinc-400 text-sm">No targets defined.</td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary

- **Volumes tab**: `statvfs` on a child ZFS dataset (`backup/snapshots`) was reporting only that dataset's own referenced bytes (~128 KB), not the pool total. Fixed by using `zfs list -Hp -o used,avail` which returns accurate pool-level stats.
- **Targets tab**: added a **Dataset Size** column showing per-target ZFS used space (including all snapshots). Fetched in a single `zfs list -rHp` call. Unprovisioned targets show "not provisioned".

## Test plan
- [x] Configuration > Volumes shows correct pool usage matching `df -h /backup`
- [x] Configuration > Targets shows Dataset Size column per target
- [x] Unprovisioned targets show "not provisioned"

🤖 Generated with [Claude Code](https://claude.com/claude-code)