### PR TITLE
feat: v2.0 ZFS snapshot retention (fs-retention.sh)

### DIFF
--- a/bin/fs-install.sh
+++ b/bin/fs-install.sh
@@ -200,7 +200,7 @@ for class in class1 class2 class3; do
 done
 
 # Other timers
-for unit in fsbackup-s3-export.timer fsbackup-scrub.timer fsbackup-logrotate-metric.timer; do
+for unit in fsbackup-retention.timer fsbackup-s3-export.timer fsbackup-scrub.timer fsbackup-logrotate-metric.timer; do
     systemctl enable "$unit" 2>/dev/null && ok "Enabled: ${unit}"
 done
 echo

--- a/bin/fs-retention.sh
+++ b/bin/fs-retention.sh
@@ -1,88 +1,165 @@
 #!/usr/bin/env bash
 set -u
+set -o pipefail
+
+# =============================================================================
+# fs-retention.sh — prune old ZFS snapshots by type (v2.0)
+#
+# Keeps the N most recent snapshots of each type per target dataset.
+# Retention counts can be overridden in fsbackup.conf:
+#
+#   KEEP_DAILY=14
+#   KEEP_WEEKLY=8
+#   KEEP_MONTHLY=12
+#   KEEP_ANNUAL=0    # 0 = keep all
+#
+# Usage:
+#   fs-retention.sh [--dry-run]
+# =============================================================================
+
 . /etc/fsbackup/fsbackup.conf
-LOG_FILE="/var/lib/fsbackup/log/backup.log"
-LOCK_FILE="/var/lock/fsbackup.lock"
 
-NODE_EXPORTER_TEXTFILE="/var/lib/node_exporter/textfile_collector"
-METRIC_FILE="${NODE_EXPORTER_TEXTFILE}/fsbackup_retention.prom"
+PRIMARY_SNAPSHOT_ROOT="${SNAPSHOT_ROOT:-/backup/snapshots}"
+ZFS_BASE="${PRIMARY_SNAPSHOT_ROOT#/}"
 
-KEEP_DAILY=14
-KEEP_WEEKLY=8
-KEEP_MONTHLY=12
+KEEP_DAILY="${KEEP_DAILY:-14}"
+KEEP_WEEKLY="${KEEP_WEEKLY:-8}"
+KEEP_MONTHLY="${KEEP_MONTHLY:-12}"
+KEEP_ANNUAL="${KEEP_ANNUAL:-0}"   # 0 = keep all
 
-ts(){ date +%Y-%m-%dT%H:%M:%S%z; }
-log(){ printf "%s %s\n" "$(ts)" "$*" >&2; }
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "Usage: $0 [--dry-run]" >&2; exit 2 ;;
+  esac
+done
 
-exec > >(tee -a "$LOG_FILE") 2>&1
+LOG_DIR="/var/lib/fsbackup/log"
+LOG_FILE="${LOG_DIR}/retention.log"
+NODEEXP_DIR="/var/lib/node_exporter/textfile_collector"
+PROM_OUT="${NODEEXP_DIR}/fsbackup_retention.prom"
 
-exec 9>"$LOCK_FILE"
-flock -n 9 || { log "[fs-retention] lock held, skipping"; exit 75; }
+mkdir -p "$LOG_DIR"
 
-prune_dirset() {
-  local type="$1" keep="$2"
-  local base="${SNAPSHOT_ROOT}/${type}"
+exec 9>/run/lock/fsbackup-retention.lock
+flock -n 9 || { echo "$(date -Is) [retention] already running, exiting"; exit 0; }
 
-  [[ -d "$base" ]] || return 0
+log() { echo "$(date -Is) [retention] $*" | tee -a "$LOG_FILE"; }
 
-  # Sort keys lexicographically works for YYYY-MM-DD, YYYY-MM, YYYY-Www
-  mapfile -t KEYS < <(ls -1 "$base" 2>/dev/null | sort || true)
-  local total="${#KEYS[@]}"
-  local removed=0
-
-  if (( total <= keep )); then
-    log "[fs-retention] ${type}: total=${total}, keep=${keep} -> nothing to prune"
-    echo "$removed"
-    return 0
-  fi
-
-  local cut=$((total - keep))
-  for ((i=0; i<cut; i++)); do
-    local k="${KEYS[$i]}"
-    log "[fs-retention] Pruning ${type}/${k}"
-    rm -rf --one-file-system "${base}/${k}"
-    removed=$((removed+1))
-  done
-
-  echo "$removed"
+# keep_count_for_type <type> → echo the keep count (0 = unlimited)
+keep_count_for_type() {
+  case "$1" in
+    daily)   echo "$KEEP_DAILY" ;;
+    weekly)  echo "$KEEP_WEEKLY" ;;
+    monthly) echo "$KEEP_MONTHLY" ;;
+    annual)  echo "$KEEP_ANNUAL" ;;
+    *)       echo 0 ;;
+  esac
 }
 
-log "[fs-retention] Starting retention pruning"
-REM_DAILY="$(prune_dirset daily "$KEEP_DAILY")"
-REM_WEEKLY="$(prune_dirset weekly "$KEEP_WEEKLY")"
-REM_MONTHLY="$(prune_dirset monthly "$KEEP_MONTHLY")"
-log "[fs-retention] Complete (daily=${REM_DAILY}, weekly=${REM_WEEKLY}, monthly=${REM_MONTHLY})"
+START_TS="$(date +%s)"
+DESTROYED=0
+KEPT=0
+FAILED=0
 
-# Metrics
-now="$(date +%s)"
+[[ "$DRY_RUN" -eq 1 ]] && log "DRY RUN — no snapshots will be destroyed"
+log "Starting retention pruning (daily=${KEEP_DAILY} weekly=${KEEP_WEEKLY} monthly=${KEEP_MONTHLY} annual=${KEEP_ANNUAL:-unlimited})"
+
+# Collect all snapshot names, grouped by dataset
+declare -A snap_lists   # dataset -> space-separated list of snapnames sorted oldest-first
+
+while IFS= read -r line; do
+  [[ "$line" == *"@"* ]] || continue
+  dataset="${line%%@*}"
+  snapname="${line##*@}"
+  [[ -z "${snap_lists[$dataset]+x}" ]] && snap_lists["$dataset"]=""
+  snap_lists["$dataset"]+="${snapname} "
+done < <(zfs list -t snapshot -r -H -o name "$ZFS_BASE" 2>/dev/null | sort)
+
+for dataset in "${!snap_lists[@]}"; do
+  # Group snapshots by type
+  declare -A by_type
+  for snapname in ${snap_lists[$dataset]}; do
+    type="${snapname%%-*}"
+    [[ -z "${by_type[$type]+x}" ]] && by_type["$type"]=""
+    by_type["$type"]+="${snapname} "
+  done
+
+  for type in "${!by_type[@]}"; do
+    keep="$(keep_count_for_type "$type")"
+    # Build sorted array (oldest first — sort is already applied above)
+    mapfile -t snaps <<< "$(echo "${by_type[$type]}" | tr ' ' '\n' | grep -v '^$' | sort)"
+    total="${#snaps[@]}"
+
+    if [[ "$keep" -eq 0 || "$total" -le "$keep" ]]; then
+      log "KEEP  ${dataset} ${type}: total=${total} keep=${keep:-unlimited} → nothing to prune"
+      KEPT=$((KEPT + total))
+      unset "by_type[$type]"
+      continue
+    fi
+
+    prune_count=$(( total - keep ))
+    KEPT=$((KEPT + keep))
+
+    for (( i=0; i<prune_count; i++ )); do
+      snap="${snaps[$i]}"
+      full="${dataset}@${snap}"
+      if [[ "$DRY_RUN" -eq 1 ]]; then
+        log "DRY   zfs destroy ${full}"
+        DESTROYED=$((DESTROYED + 1))
+      else
+        log "DESTROY ${full}"
+        if zfs destroy "$full" 2>>"$LOG_FILE"; then
+          DESTROYED=$((DESTROYED + 1))
+        else
+          log "ERROR  failed to destroy ${full}"
+          FAILED=$((FAILED + 1))
+        fi
+      fi
+    done
+    unset "by_type[$type]"
+  done
+
+  unset by_type
+  declare -A by_type
+done
+
+END_TS="$(date +%s)"
+DURATION=$(( END_TS - START_TS ))
+EXIT_CODE=$([[ "$FAILED" -gt 0 ]] && echo 1 || echo 0)
+
+log "Retention complete: destroyed=${DESTROYED} kept=${KEPT} failed=${FAILED} duration=${DURATION}s"
+
+# Prometheus metrics
 tmp="$(mktemp)"
-
-## Ensure unset and empty values are set to 0.
-REM_DAILY="${REM_DAILY:-0}"
-REM_WEEKLY="${REM_WEEKLY:-0}"
-REM_MONTHLY="${REM_MONTHLY:-0}"
-
 cat >"$tmp" <<EOF
 # HELP fsbackup_retention_last_run_seconds Unix timestamp of last retention run
 # TYPE fsbackup_retention_last_run_seconds gauge
-fsbackup_retention_last_run_seconds $now
+fsbackup_retention_last_run_seconds $(date +%s)
 
-# HELP fsbackup_retention_removed_daily Number of daily snapshot keys removed
-# TYPE fsbackup_retention_removed_daily gauge
-fsbackup_retention_removed_daily $REM_DAILY
+# HELP fsbackup_retention_last_exit_code Exit code of last retention run (0=success)
+# TYPE fsbackup_retention_last_exit_code gauge
+fsbackup_retention_last_exit_code ${EXIT_CODE}
 
-# HELP fsbackup_retention_removed_weekly Number of weekly snapshot keys removed
-# TYPE fsbackup_retention_removed_weekly gauge
-fsbackup_retention_removed_weekly $REM_WEEKLY
+# HELP fsbackup_retention_destroyed_total Snapshots destroyed in this run
+# TYPE fsbackup_retention_destroyed_total gauge
+fsbackup_retention_destroyed_total ${DESTROYED}
 
-# HELP fsbackup_retention_removed_monthly Number of monthly snapshot keys removed
-# TYPE fsbackup_retention_removed_monthly gauge
-fsbackup_retention_removed_monthly $REM_MONTHLY
+# HELP fsbackup_retention_kept_total Snapshots kept (within policy) in this run
+# TYPE fsbackup_retention_kept_total gauge
+fsbackup_retention_kept_total ${KEPT}
+
+# HELP fsbackup_retention_failed_total Snapshots that failed to destroy in this run
+# TYPE fsbackup_retention_failed_total gauge
+fsbackup_retention_failed_total ${FAILED}
+
+# HELP fsbackup_retention_duration_seconds Duration of retention run in seconds
+# TYPE fsbackup_retention_duration_seconds gauge
+fsbackup_retention_duration_seconds ${DURATION}
 EOF
-
-chmod 0644 "$tmp" 2>/dev/null || true
 chgrp nodeexp_txt "$tmp" 2>/dev/null || true
-mv "$tmp" "$METRIC_FILE"
+chmod 0644 "$tmp"
+mv "$tmp" "$PROM_OUT"
 
-exit 0
-
+exit "$EXIT_CODE"

--- a/conf/fsbackup.conf.example
+++ b/conf/fsbackup.conf.example
@@ -21,6 +21,17 @@ CLASS3_MONTHLY_SCHEDULE="*-*-01 04:00"
 # CLASS3_DAILY_SCHEDULE=""     # omit to disable daily class3 runs
 
 # =============================================================================
+# Retention — how many ZFS snapshots of each type to keep per target
+# Applied by fs-retention.sh (runs daily via fsbackup-retention.timer)
+# KEEP_ANNUAL=0 means keep all annual snapshots indefinitely
+# =============================================================================
+
+KEEP_DAILY=14
+KEEP_WEEKLY=8
+KEEP_MONTHLY=12
+KEEP_ANNUAL=0
+
+# =============================================================================
 # S3 export
 # =============================================================================
 

--- a/systemd/fsbackup-retention.service
+++ b/systemd/fsbackup-retention.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=fsbackup ZFS snapshot retention pruning
+After=fsbackup-runner-daily@class1.service fsbackup-runner-daily@class2.service
+
+[Service]
+UMask=0022
+Type=oneshot
+User=fsbackup
+ExecStart=/opt/fsbackup/bin/fs-retention.sh

--- a/systemd/fsbackup-retention.timer
+++ b/systemd/fsbackup-retention.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=fsbackup ZFS snapshot retention pruning (daily)
+
+[Timer]
+OnCalendar=*-*-* 06:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Rewrites `fs-retention.sh` for v2.0's flat ZFS dataset structure. Sanoid cannot be used here — it only prunes snapshots it creates itself (named `autosnap_*`), and our snapshots use a different naming convention (`daily-YYYY-MM-DD`, `weekly-YYYY-Www`, etc.).

- **fs-retention.sh**: enumerates all snapshots via `zfs list -t snapshot -r`, groups by dataset + type, destroys oldest beyond keep count with `zfs destroy`. Supports `--dry-run`. Emits Prometheus metrics.
- **fsbackup-retention.{service,timer}**: runs daily at 06:00 as `fsbackup` user.
- **fsbackup.conf.example**: adds `KEEP_DAILY=14`, `KEEP_WEEKLY=8`, `KEEP_MONTHLY=12`, `KEEP_ANNUAL=0` (unlimited).
- **fs-install.sh**: enables `fsbackup-retention.timer` during install.

## Deploy on live system

```bash
# Sync scripts
sudo rsync -a --delete --exclude='.git' --exclude='web/.venv' --exclude='web/.env' --exclude='conf/targets.yml' \
  /home/crash/projects/fsbackup/ /opt/fsbackup/

# Add KEEP_* vars to /etc/fsbackup/fsbackup.conf if not present
echo 'KEEP_DAILY=14
KEEP_WEEKLY=8
KEEP_MONTHLY=12
KEEP_ANNUAL=0' | sudo tee -a /etc/fsbackup/fsbackup.conf

# Install and enable timer
sudo cp /opt/fsbackup/systemd/fsbackup-retention.{service,timer} /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now fsbackup-retention.timer

# Test dry run first
sudo -u fsbackup /opt/fsbackup/bin/fs-retention.sh --dry-run
```

## Test plan
- [x] `fs-retention.sh --dry-run` logs correctly without destroying anything
- [ ] After accumulating >14 daily snapshots on one target, `fs-retention.sh` destroys the oldest
- [x] Prometheus metric file written to `/var/lib/node_exporter/textfile_collector/fsbackup_retention.prom`
- [ ] `systemctl status fsbackup-retention.timer` shows enabled and next trigger at 06:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)