### PR TITLE
feat(web): mobile UI + PWA support

### DIFF
--- a/web/static/manifest.json
+++ b/web/static/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "fsbackup",
+  "short_name": "fsbackup",
+  "description": "ZFS-native backup manager for home labs",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#09090b",
+  "theme_color": "#f97316",
+  "icons": [
+    {
+      "src": "/static/icon-256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,0 +1,41 @@
+const CACHE = 'fsbackup-v1';
+const STATIC_ASSETS = [
+  '/static/icon.svg',
+  '/static/favicon.svg',
+  '/static/favicon.ico',
+  '/static/icon-256.png',
+  '/static/icon-512.png',
+];
+
+self.addEventListener('install', e => {
+  e.waitUntil(
+    caches.open(CACHE).then(c => c.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', e => {
+  if (e.request.method !== 'GET') return;
+  const url = new URL(e.request.url);
+  if (url.pathname.startsWith('/static/')) {
+    e.respondWith(
+      caches.match(e.request).then(cached => {
+        if (cached) return cached;
+        return fetch(e.request).then(res => {
+          const clone = res.clone();
+          caches.open(CACHE).then(c => c.put(e.request, clone));
+          return res;
+        });
+      })
+    );
+  }
+});

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -3,9 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#f97316">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="fsbackup">
   <title>{% block title %}fsbackup{% endblock %}</title>
   <link rel="icon" href="/static/favicon.ico" sizes="any"/>
   <link rel="icon" href="/static/favicon.svg" type="image/svg+xml"/>
+  <link rel="apple-touch-icon" href="/static/icon-256.png"/>
+  <link rel="manifest" href="/static/manifest.json"/>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   <script>
@@ -28,7 +34,8 @@
             }
           }
         }
-      }
+      },
+      safelist: ['-translate-x-full', 'translate-x-0']
     }
   </script>
   <style>
@@ -49,10 +56,16 @@
 </head>
 <body class="h-full bg-zinc-100 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 font-sans transition-colors duration-150">
 
+<!-- Mobile sidebar backdrop -->
+<div id="sidebar-backdrop"
+     class="fixed inset-0 z-30 bg-black/50 hidden lg:hidden"
+     onclick="closeSidebar()"></div>
+
 <div class="flex h-full">
 
-  <!-- Sidebar -->
-  <aside class="w-56 shrink-0 bg-white dark:bg-zinc-900 border-r border-zinc-200 dark:border-zinc-800 flex flex-col">
+  <!-- Sidebar (off-canvas on mobile, static on lg+) -->
+  <aside id="sidebar"
+         class="fixed lg:static inset-y-0 left-0 z-40 w-56 shrink-0 bg-white dark:bg-zinc-900 border-r border-zinc-200 dark:border-zinc-800 flex flex-col -translate-x-full lg:translate-x-0 transition-transform duration-200">
     <div class="px-5 py-5 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between">
       <div class="flex items-center gap-2.5">
         <img src="/static/icon.svg" alt="" class="h-7 w-7 rounded-lg shrink-0"/>
@@ -114,12 +127,30 @@
     </div>
   </aside>
 
-  <!-- Main content -->
-  <main class="flex-1 overflow-y-auto bg-zinc-50 dark:bg-zinc-950">
-    <div class="px-8 py-8 max-w-7xl mx-auto">
-      {% block content %}{% endblock %}
+  <!-- Right column: mobile top bar + main content -->
+  <div class="flex-1 flex flex-col min-w-0 overflow-hidden">
+
+    <!-- Mobile top bar -->
+    <div class="lg:hidden flex items-center gap-3 px-4 h-14 bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 shrink-0">
+      <button onclick="openSidebar()"
+              class="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+              aria-label="Open navigation">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
+        </svg>
+      </button>
+      <img src="/static/icon.svg" alt="" class="h-6 w-6 rounded-md shrink-0"/>
+      <span class="font-bold text-zinc-900 dark:text-white tracking-tight">fsbackup</span>
     </div>
-  </main>
+
+    <!-- Main content -->
+    <main class="flex-1 overflow-y-auto bg-zinc-50 dark:bg-zinc-950">
+      <div class="px-4 sm:px-8 py-6 sm:py-8 max-w-7xl mx-auto">
+        {% block content %}{% endblock %}
+      </div>
+    </main>
+
+  </div>
 
 </div>
 
@@ -127,6 +158,32 @@
   function toggleTheme() {
     const isDark = document.documentElement.classList.toggle('dark');
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  }
+
+  function openSidebar() {
+    document.getElementById('sidebar').classList.remove('-translate-x-full');
+    document.getElementById('sidebar').classList.add('translate-x-0');
+    document.getElementById('sidebar-backdrop').classList.remove('hidden');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    document.getElementById('sidebar').classList.add('-translate-x-full');
+    document.getElementById('sidebar').classList.remove('translate-x-0');
+    document.getElementById('sidebar-backdrop').classList.add('hidden');
+    document.body.style.overflow = '';
+  }
+
+  // Close sidebar on nav link click (mobile)
+  document.querySelectorAll('#sidebar a[href]').forEach(a => {
+    a.addEventListener('click', () => {
+      if (window.innerWidth < 1024) closeSidebar();
+    });
+  });
+
+  // Register service worker
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/static/sw.js').catch(() => {});
   }
 </script>
 </body>

--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -33,7 +33,8 @@
       <p class="text-xs text-zinc-400 mt-0.5">Hosts derived from targets.yml. Use <code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded">fs-trust-host.sh</code> to seed SSH host keys for any new host before adding targets.</p>
     </div>
     {% if hosts %}
-    <table class="w-full text-sm">
+    <div class="overflow-x-auto">
+    <table class="w-full text-sm min-w-max">
       <thead>
         <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
           <th class="px-5 py-3 font-medium">Hostname</th>
@@ -55,6 +56,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
     {% else %}
     <div class="px-5 py-8 text-center text-zinc-400 text-sm">
       No hosts found — check that targets.yml exists at <code class="font-mono">/etc/fsbackup/targets.yml</code>.
@@ -92,7 +94,8 @@
   <div class="mb-6">
     <h2 class="text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-3">{{ class_name }}</h2>
     <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden shadow-sm">
-      <table class="w-full text-sm">
+      <div class="overflow-x-auto">
+      <table class="w-full text-sm min-w-max">
         <thead>
           <tr class="border-b border-zinc-200 dark:border-zinc-800 text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50">
             <th class="px-4 py-3 font-medium">Target</th>
@@ -141,6 +144,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
     </div>
   </div>
   {% endfor %}

--- a/web/templates/logs.html
+++ b/web/templates/logs.html
@@ -107,7 +107,7 @@
      class="fixed inset-0 z-50 hidden items-center justify-center bg-black/70 backdrop-blur-sm p-4"
      onclick="if(event.target===this) closeLogModal()">
   <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl flex flex-col w-full max-w-6xl resize overflow-auto"
-       style="height:85vh; min-width:400px; min-height:300px;">
+       style="height:85vh; min-height:300px;">
     <div class="flex items-center justify-between px-4 py-2.5 border-b border-zinc-700 shrink-0">
       <span id="log-modal-title" class="text-xs font-semibold text-zinc-300"></span>
       <div class="flex items-center gap-3">

--- a/web/templates/run.html
+++ b/web/templates/run.html
@@ -149,7 +149,7 @@
      class="fixed inset-0 z-50 hidden items-center justify-center bg-black/70 backdrop-blur-sm p-4"
      onclick="if(event.target===this) closeJournalModal()">
   <div class="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl flex flex-col w-full max-w-5xl resize overflow-auto"
-       style="height:80vh; min-width:400px; min-height:300px;">
+       style="height:80vh; min-height:300px;">
     <!-- Header -->
     <div class="flex items-center justify-between px-4 py-2.5 border-b border-zinc-700 shrink-0">
       <span id="journal-modal-title" class="text-xs font-mono text-zinc-300"></span>

--- a/web/templates/snapshots.html
+++ b/web/templates/snapshots.html
@@ -78,7 +78,8 @@
 
 <!-- Table -->
 <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden shadow-sm">
-  <table class="w-full text-sm">
+  <div class="overflow-x-auto">
+  <table class="w-full text-sm min-w-max">
     <thead>
       <tr class="border-b border-zinc-200 dark:border-zinc-800 text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50">
         <th class="px-4 py-3 font-medium">Tier</th>
@@ -93,6 +94,7 @@
       {% include "partials/snapshot_rows.html" %}
     </tbody>
   </table>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary

- **Off-canvas sidebar**: hidden on mobile, slides in with hamburger toggle; backdrop closes it; auto-closes on nav click
- **Mobile top bar**: visible on small screens with hamburger, icon, and app name
- **PWA**: `manifest.json` + `sw.js` service worker; `<meta>` tags for Apple home screen; caches static assets for offline icon display
- **Table overflow**: `overflow-x-auto` wrappers on Snapshots, Configuration → Hosts, and Configuration → Targets tables
- **Modal sizing**: removed hardcoded `min-width: 400px` from journal and log pop-out modals so they fit narrow screens

Closes #64

## Test plan

- [x] Open on mobile/narrow viewport — sidebar should be hidden, top bar visible
- [x] Hamburger opens sidebar; backdrop + nav link click close it
- [x] On desktop (≥1024px) sidebar should always be visible, top bar hidden
- [x] Visit `/static/manifest.json` — valid JSON with icons
- [x] Chrome → Add to Home Screen prompt appears (after HTTPS or localhost)
- [x] Snapshots, Configuration > Targets tables scroll horizontally on narrow screen
- [x] Journal modal (Run page) and log modal (Logs page) fit on mobile without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)