### PR TITLE
fix: S3 export, UI polish, schedule tab, docs update

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,161 +13,149 @@ policy, and offsite strategy.
 
 Frequently changing data: app volumes, databases, personal files.
 
-- **Schedule**: daily at ~01:49
-- **Tiers**: daily, weekly, monthly, annual
-- **Mirror**: yes (to `/backup2`)
-- **Annual**: December monthly snapshot promoted to annual on Jan 5
-- **Offsite**: via S3 (planned — see [Offsite](#offsite))
+- **Schedule**: daily at ~01:45, weekly Sat ~02:00, monthly 1st ~03:00
+- **Tiers**: daily, weekly, monthly
+- **Offsite**: S3 — weekly + monthly uploaded nightly via `fsbackup-s3-export.timer`
 
 ### class2 — Infrastructure config
 
-Slowly changing config: docker stacks, nginx, bind, webmin, etc.
+Slowly changing config: docker stacks, nginx, bind, etc.
 
-- **Schedule**: daily at ~02:15
-- **Tiers**: daily, weekly, monthly (no annual)
-- **Mirror**: yes (to `/backup2`)
-- **Offsite**: via S3 (planned — see [Offsite](#offsite))
+- **Schedule**: daily at ~02:15, weekly Sat ~02:30
+- **Tiers**: daily, weekly (monthly disabled — `CLASS2_MONTHLY_SCHEDULE` commented out in `fsbackup.conf`)
+- **Offsite**: S3 — weekly uploaded nightly via `fsbackup-s3-export.timer`
 
 ### class3 — Large archives
 
 Large, infrequently changing data: photo libraries, raw camera files.
 
-- **Schedule**: monthly (1st of each month at ~04:45)
-- **Tiers**: monthly only (no daily, no weekly, no annual)
-- **Mirror**: **no** — excluded via `MIRROR_SKIP_CLASSES=class3` in `fsbackup.conf`
-- **Offsite**: M-DISC annually (manual), USB external drive monthly (manual)
+- **Schedule**: monthly (1st of each month at ~04:00)
+- **Tiers**: monthly only (no daily, no weekly)
+- **Offsite**: excluded from S3 by default (`S3_SKIP_CLASSES=class3`); manual M-DISC/USB
 
 ---
 
 ## Snapshot path structure
 
+fsbackup v2 uses ZFS-native snapshots. Each target has a dedicated ZFS dataset; snapshots
+are named with a tier prefix and a date stamp.
+
+**ZFS dataset path**: `backup/snapshots/<class>/<target>`
+
+**Snapshot names**:
+
+| Tier | Format | Example |
+|---|---|---|
+| daily | `@daily-YYYY-MM-DD` | `@daily-2026-04-11` |
+| weekly | `@weekly-YYYY-Www` | `@weekly-2026-W15` |
+| monthly | `@monthly-YYYY-MM` | `@monthly-2026-04` |
+
+**Filesystem access** (read-only via `.zfs` automount):
+
 ```
-/backup/snapshots/<tier>/<date>/<class>/<target-id>/
+/backup/snapshots/<class>/<target>/.zfs/snapshot/<snapshot-name>/
 ```
 
-| Component | Values |
-|---|---|
-| `tier` | `daily`, `weekly`, `monthly`, `annual` |
-| `date` | `YYYY-MM-DD` (daily), `YYYY-Www` (weekly), `YYYY-MM` (monthly), `YYYY` (annual) |
-| `class` | `class1`, `class2`, `class3` |
-| `target-id` | as defined in `targets.yml` |
-
-Example: `/backup/snapshots/daily/2026-03-05/class1/mosquitto.data/`
-
-The mirror follows the same structure under `/backup2/snapshots/`.
+Example: `/backup/snapshots/class1/technicom.files/.zfs/snapshot/weekly-2026-W15/`
 
 ---
 
 ## Retention policy
 
-### Primary (`/backup/snapshots`)
-
 | Tier | Kept |
 |---|---|
-| daily | 14 days |
-| weekly | 8 weeks |
-| monthly | 12 months |
-| annual | indefinite (never pruned by retention script) |
+| daily | 14 (`KEEP_DAILY`) |
+| weekly | 8 (`KEEP_WEEKLY`) |
+| monthly | 12 (`KEEP_MONTHLY`) |
 
-Retention runs daily at ~03:00 via `fsbackup-retention.timer`.
-
-### Mirror (`/backup2/snapshots`)
-
-| Tier | Kept |
-|---|---|
-| daily | 14 days |
-| weekly | 12 weeks |
-| monthly | 24 months |
-
-Mirror retention runs daily at ~04:00 via `fsbackup-mirror-retention.timer`.
-Mirror keeps longer weekly/monthly history than primary due to available space.
+Retention runs daily at ~06:00 via `fsbackup-retention.timer` (after overnight backup windows).
 
 ---
 
-## Promotion
+## Promotion and mirroring
 
-Promotion creates hardlinked copies of daily snapshots into higher tiers.
-Hardlinks mean promoted snapshots share blocks with the daily source — no extra disk
-space for unchanged files.
-
-| Event | Action | Condition |
-|---|---|---|
-| Daily → weekly | Promote today's daily to `weekly/YYYY-Www/` | Runs on Monday (DOW=1) |
-| Daily → monthly | Promote today's daily to `monthly/YYYY-MM/` | Runs on 1st of month |
-| Monthly Dec → annual | Promote December monthly to `annual/YYYY/` | Runs Jan 5 each year |
-
-Only `class1` is promoted to annual. `class2` and `class3` have no annual tier.
-
-Promotion only proceeds if the source daily snapshot has a clean exit code
-(`.fsbackup_class_exit_code` = 0). A failed daily is not promoted.
-
-Annual snapshots are made read-only (`chmod -R u-w`) immediately after creation.
-
----
-
-## Mirror logic
-
-The mirror (`fs-mirror.sh`) runs in two modes:
-
-### daily mode
-
-Copies today's daily snapshot from primary to mirror, skipping any classes listed in
-`MIRROR_SKIP_CLASSES`. Runs at ~02:30 after the runner completes.
-
-### promote mode
-
-Syncs the entire `weekly/` and `monthly/` trees from primary to mirror, with per-class
-excludes for any classes in `MIRROR_SKIP_CLASSES`. Runs at ~03:40 after promotion.
-
-Mirror uses `rsync -a --ignore-existing` so it never overwrites data already on the mirror.
-
-Classes in `MIRROR_SKIP_CLASSES` (currently `class3`) are never mirrored to `/backup2`.
+Not implemented in v2.0. Each tier (daily/weekly/monthly) is taken independently by
+its own runner timer. There are no hardlink promotions or mirror copies in this release.
 
 ---
 
 ## Offsite strategy
 
-### class1 and class2
+### S3 (class1 + class2)
 
-S3 offsite is planned but not yet implemented. The existing `fs-export-s3.sh` script is
-broken and needs a complete rewrite before use.
+Weekly and monthly ZFS snapshots are encrypted with `age` and uploaded to S3 nightly
+by `fs-export-s3.sh`. The script is idempotent: it enumerates all current ZFS snapshots
+and uploads any weekly/monthly/annual snapshots not already present in the bucket.
+This means the first successful run will backfill all previously missed snapshots.
 
-_This section will be updated when the S3 export system is designed and implemented._
+S3 key layout: `<tier>/<class>/<target>/<target>--<date>.tar.zst.age`
+
+| Setting | Value |
+|---|---|
+| Bucket | `S3_BUCKET` in `fsbackup.conf` |
+| AWS profile | `S3_AWS_PROFILE` (default: `fsbackup`) |
+| Credentials | `/var/lib/fsbackup/.aws/credentials` |
+| Encryption | `age` public key at `/etc/fsbackup/age.pub` |
+| Skip classes | `S3_SKIP_CLASSES` (default: `class3`) |
+
+The `age` private key is **not stored on the server**. Keep it offline (e.g., Bitwarden,
+encrypted USB). Without it, S3 objects cannot be decrypted for restore.
 
 ### class3 — photos and large archives
 
-class3 is not mirrored to `/backup2`. Offsite copies are made manually:
+Excluded from S3 by default (`S3_SKIP_CLASSES=class3`). Manual offsite copies:
 
 | Frequency | Medium | Process |
 |---|---|---|
-| Monthly | USB external drive | Manual copy from `/backup/snapshots/monthly/YYYY-MM/class3/` |
+| Monthly | USB external drive | Manual copy from snapshot `.zfs/snapshot/monthly-YYYY-MM/` |
 | Annual | M-DISC (archival optical disc) | Manual burn from the December monthly snapshot |
-
-M-DISC is suitable for class3 because the data is large, changes slowly, and benefits
-from media that does not degrade over time. The annual burn corresponds to the same
-snapshot that would be promoted to annual for class1.
 
 ---
 
 ## Timer schedule
 
-All times approximate. Timers use `RandomizedDelaySec` to avoid thundering herd.
+All times approximate. Runner timers use `RandomizedDelaySec=5m`.
+
+**Nightly (every day)**
 
 | Time | Unit | Action |
 |---|---|---|
-| 01:17 | `fsbackup-doctor@class1` | SSH/path health check, orphan scan |
-| 01:40 | `fs-db-export@paperlessngx` | DB dump to export dir |
-| 01:49 | `fsbackup-runner@class1` | Daily snapshot — class1 |
-| 02:05 | `fsbackup-doctor@class2` | SSH/path health check |
-| 02:15 | `fsbackup-runner@class2` | Daily snapshot — class2 |
-| 02:30 | `fsbackup-mirror-daily` | Mirror today's daily (class1 + class2) |
-| 03:00 | `fsbackup-retention` | Prune primary snapshots |
-| 03:30 | `fsbackup-promote` | Promote daily → weekly/monthly |
-| 03:40 | `fsbackup-mirror-promote` | Mirror weekly + monthly tiers |
-| 04:00 | `fsbackup-mirror-retention` | Prune mirror snapshots |
-| 04:15 (1st) | `fsbackup-doctor@class3` | Health check (runs 1st of month) |
-| 04:45 (1st) | `fsbackup-runner@class3` | Monthly snapshot — class3 (runs 1st of month) |
-| Jan 5, 03:00 | `fsbackup-annual-promote` | Promote Dec monthly → annual (class1 only) |
+| ~01:45 | `fsbackup-runner-daily@class1` | Daily rsync + ZFS snapshot — class1 |
+| 02:05 | `fsbackup-doctor@class1` | SSH/path health check — class1 |
+| 02:05 | `fsbackup-doctor@class2` | SSH/path health check — class2 |
+| 02:05 | `fsbackup-doctor@class3` | SSH/path health check — class3 |
+| ~02:15 | `fsbackup-runner-daily@class2` | Daily rsync + ZFS snapshot — class2 |
+| 04:30 | `fsbackup-s3-export` | Encrypt + upload weekly/monthly to S3 |
+| 06:00 | `fsbackup-retention` | Prune old ZFS snapshots (all classes) |
+| 00:00 | `fsbackup-logrotate-metric` | Rotate Prometheus `.prom` files |
+
+**Weekly (Saturday)**
+
+| Time | Unit | Action |
+|---|---|---|
+| Sat ~02:00 | `fsbackup-runner-weekly@class1` | Weekly rsync + ZFS snapshot — class1 |
+| Sat ~02:30 | `fsbackup-runner-weekly@class2` | Weekly rsync + ZFS snapshot — class2 |
+
+**Monthly (1st of month)**
+
+| Time | Unit | Action |
+|---|---|---|
+| 1st ~03:00 | `fsbackup-runner-monthly@class1` | Monthly rsync + ZFS snapshot — class1 |
+| 1st ~04:00 | `fsbackup-runner-monthly@class3` | Monthly rsync + ZFS snapshot — class3 |
+
+**Monthly (5th of month)**
+
+| Time | Unit | Action |
+|---|---|---|
+| 5th 03:00 | `fsbackup-scrub` | ZFS pool scrub |
+
+> **Note**: `fsbackup-runner-monthly@class2` is intentionally disabled
+> (`CLASS2_MONTHLY_SCHEDULE` commented out in `fsbackup.conf`). class2 retains
+> 14 days of dailies and 8 weeks of weeklies, which is sufficient for config data.
+
+> **Schedule note**: On Saturdays, class1 daily (01:45) and weekly (02:00) run only
+> 15 minutes apart. If the daily backup takes longer than ~15 minutes, both runners
+> may overlap. Check `fs-runner.sh` locking if this causes issues.
 
 ---
 
@@ -210,3 +198,12 @@ All times approximate. Timers use `RandomizedDelaySec` to avoid thundering herd.
 | `fsbackup_annual_promote_success{year}` | 1 if annual promote succeeded |
 | `fsbackup_doctor_duration_seconds{class}` | Doctor run duration |
 | `fsbackup_ssh_host_key_present{host,fingerprint}` | 1 if SSH host key is trusted |
+| `fsbackup_s3_last_success` | Unix timestamp of last S3 export run |
+| `fsbackup_s3_last_exit_code` | Exit code of last S3 export run (0=success) |
+| `fsbackup_s3_uploaded_total` | Objects uploaded in last S3 run |
+| `fsbackup_s3_skipped_total` | Objects skipped (already in S3) in last run |
+| `fsbackup_s3_failed_total` | Objects that failed to upload in last run |
+| `fsbackup_s3_bytes_total` | Bytes uploaded in last S3 run |
+| `fsbackup_s3_duration_seconds` | Duration of last S3 export run |
+| `fsbackup_s3_target_last_upload{tier,class,target}` | Timestamp of last successful upload per target |
+| `fsbackup_s3_target_last_failure{tier,class,target}` | Timestamp of last upload failure per target |

--- a/s3/fs-export-s3.sh
+++ b/s3/fs-export-s3.sh
@@ -35,6 +35,7 @@ LOG_FILE="${LOG_DIR}/s3-export.log"
 NODEEXP_DIR="/var/lib/node_exporter/textfile_collector"
 PROM_OUT="${NODEEXP_DIR}/fsbackup_s3.prom"
 PROM_TMP="$(mktemp)"
+trap 'rm -f "$PROM_TMP"' EXIT
 
 mkdir -p "$LOG_DIR"
 
@@ -155,7 +156,7 @@ while IFS= read -r snapfull; do
       >>"$PROM_TMP"
   fi
 
-done < <(zfs list -t snapshot -r -H -o name "$ZFS_BASE" 2>/dev/null | sort)
+done < <(zfs list -t snapshot -r -H -o name "$ZFS_BASE" 2>>"$LOG_FILE" | sort)
 
 END_TS="$(date +%s)"
 DURATION=$((END_TS - START_TS))

--- a/web/main.py
+++ b/web/main.py
@@ -357,22 +357,25 @@ async def logout(request: Request):
 
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request):
-    # Quick status: last exit code prom files
-    prom_dir = Path("/var/lib/node_exporter/textfile_collector")
+    # Class runner status from prom files
     class_status = {}
     for cls in CLASSES:
-        prom = prom_dir / f"fsbackup_runner_{cls}.prom"
         status = "unknown"
-        if prom.exists():
-            for line in prom.read_text().splitlines():
-                if line.startswith("fsbackup_runner_last_exit_code{"):
-                    status = "ok" if line.split()[-1] == "0" else "error"
-                    break
+        try:
+            prom = PROM_DIR / f"fsbackup_runner_{cls}.prom"
+            if prom.exists():
+                for line in prom.read_text(errors="replace").splitlines():
+                    if line.startswith("fsbackup_runner_last_exit_code{"):
+                        status = "ok" if line.split()[-1] == "0" else "error"
+                        break
+        except Exception:
+            pass
         class_status[cls] = status
 
     return templates.TemplateResponse("index.html", {
         "request":      request,
         "class_status": class_status,
+        "s3_status":    _parse_s3_status(),
     })
 
 
@@ -740,6 +743,73 @@ _LOG_SECTIONS = [
 ]
 
 
+def _humanize_age(ts: int) -> tuple[str, str]:
+    """Return (relative string, absolute formatted) for a Unix timestamp."""
+    if ts <= 0:
+        return "never", "—"
+    dt  = datetime.fromtimestamp(ts)
+    age = datetime.now() - dt
+    if age.days > 0:
+        rel = f"{age.days}d ago"
+    elif age.seconds >= 3600:
+        rel = f"{age.seconds // 3600}h ago"
+    elif age.seconds >= 60:
+        rel = f"{age.seconds // 60}m ago"
+    else:
+        rel = "just now"
+    return rel, dt.strftime("%Y-%m-%d %H:%M")
+
+
+def _humanize_bytes(n: int) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if n < 1024 or unit == "TiB":
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} B"
+        n //= 1024
+    return str(n)
+
+
+def _parse_s3_status() -> dict | None:
+    """Parse fsbackup_s3.prom and return a human-readable status dict, or None if absent."""
+    prom = PROM_DIR / "fsbackup_s3.prom"
+    if not prom.exists():
+        return None
+    raw: dict[str, str] = {}
+    try:
+        for line in prom.read_text(errors="replace").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            metric = parts[0].split("{")[0]
+            raw[metric] = parts[1]
+    except Exception:
+        return None
+    try:
+        exit_code    = int(float(raw.get("fsbackup_s3_last_exit_code",   "1")))
+        last_ts      = int(float(raw.get("fsbackup_s3_last_success",     "0")))
+        uploaded     = int(float(raw.get("fsbackup_s3_uploaded_total",   "0")))
+        skipped      = int(float(raw.get("fsbackup_s3_skipped_total",    "0")))
+        failed       = int(float(raw.get("fsbackup_s3_failed_total",     "0")))
+        bytes_total  = int(float(raw.get("fsbackup_s3_bytes_total",      "0")))
+        duration     = int(float(raw.get("fsbackup_s3_duration_seconds", "0")))
+    except (ValueError, TypeError):
+        return None
+    last_run, last_run_fmt = _humanize_age(last_ts)
+    dur_str = f"{duration // 60}m {duration % 60}s" if duration >= 60 else f"{duration}s"
+    return {
+        "status":       "ok" if exit_code == 0 else "error",
+        "last_run":     last_run,
+        "last_run_fmt": last_run_fmt,
+        "uploaded":     uploaded,
+        "skipped":      skipped,
+        "failed":       failed,
+        "bytes":        _humanize_bytes(bytes_total),
+        "duration":     dur_str,
+    }
+
+
 def _parse_prom_files() -> list[dict]:
     """Read all fsbackup*.prom files and return parsed metric rows."""
     rows: list[dict] = []
@@ -798,47 +868,78 @@ async def logs_page(request: Request):
 # Configuration page
 # ---------------------------------------------------------------------------
 
-def _load_crontab() -> list[dict]:
-    """Parse fsbackup.crontab into a list of {schedule, command, label} dicts."""
-    # Human-readable labels for known job patterns
-    _LABELS = {
-        "fs-logrotate-metric.sh": "Logrotate health metric",
-        "fs-doctor.sh --class class1": "Doctor — class1",
-        "fs-doctor.sh --class class2": "Doctor — class2",
-        "fs-doctor.sh --class class3": "Doctor — class3",
-        "fs-db-export.sh": "DB export",
-        "fs-runner.sh daily --class class1": "Backup runner — class1 (daily)",
-        "fs-runner.sh daily --class class2": "Backup runner — class2 (daily)",
-        "fs-runner.sh monthly --class class3": "Backup runner — class3 (monthly)",
-        "fs-mirror.sh daily": "Mirror — daily pass",
-        "fs-retention.sh": "Retention",
-        "fs-promote.sh": "Promote daily→weekly/monthly",
-        "fs-mirror.sh promote": "Mirror — promote pass",
-        "fs-mirror-retention.sh": "Mirror retention",
-        "fs-export-s3.sh": "S3 export",
-        "fs-annual-promote.sh": "Annual promote (Jan 5)",
-    }
-
-    entries = []
+def _s3_bucket_stats() -> dict | None:
+    """List all objects in the S3 bucket and return total count and size."""
     try:
-        lines = CRONTAB_FILE.read_text().splitlines()
+        s3 = s3_client()
+        paginator = s3.get_paginator("list_objects_v2")
+        total_size  = 0
+        total_count = 0
+        for page in paginator.paginate(Bucket=S3_BUCKET):
+            for obj in page.get("Contents", []):
+                total_size  += obj["Size"]
+                total_count += 1
+        return {"size": total_size, "count": total_count, "fmt_size": _humanize_bytes(total_size)}
     except Exception:
-        return entries
+        return None
 
-    for line in lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        parts = stripped.split(None, 5)
-        if len(parts) < 6:
-            continue
-        schedule = " ".join(parts[:5])
-        command  = parts[5]
-        label = next(
-            (lbl for key, lbl in _LABELS.items() if key in command),
-            command.split("/")[-1],
-        )
-        entries.append({"schedule": schedule, "command": command, "label": label})
+
+def _load_schedule() -> list[dict]:
+    """Build timer schedule from fsbackup.conf (runner timers) and static timer values."""
+    conf_vars: dict[str, str] = {}
+    try:
+        for line in Path("/etc/fsbackup/fsbackup.conf").read_text().splitlines():
+            stripped = line.strip()
+            # Skip blank lines and comments (including commented-out assignments)
+            if not stripped or stripped.startswith("#"):
+                continue
+            if "=" not in stripped:
+                continue
+            key, _, val = stripped.partition("=")
+            conf_vars[key.strip()] = val.strip().strip('"')
+    except Exception:
+        pass
+
+    entries: list[dict] = []
+
+    # Runner timers — OnCalendar driven by CLASS*_SCHEDULE in fsbackup.conf
+    runner_map = [
+        ("Daily backup — class1",   "fsbackup-runner-daily@class1",   "CLASS1_DAILY_SCHEDULE"),
+        ("Weekly backup — class1",  "fsbackup-runner-weekly@class1",  "CLASS1_WEEKLY_SCHEDULE"),
+        ("Monthly backup — class1", "fsbackup-runner-monthly@class1", "CLASS1_MONTHLY_SCHEDULE"),
+        ("Daily backup — class2",   "fsbackup-runner-daily@class2",   "CLASS2_DAILY_SCHEDULE"),
+        ("Weekly backup — class2",  "fsbackup-runner-weekly@class2",  "CLASS2_WEEKLY_SCHEDULE"),
+        ("Monthly backup — class2", "fsbackup-runner-monthly@class2", "CLASS2_MONTHLY_SCHEDULE"),
+        ("Monthly backup — class3", "fsbackup-runner-monthly@class3", "CLASS3_MONTHLY_SCHEDULE"),
+    ]
+    for label, unit, conf_key in runner_map:
+        schedule = conf_vars.get(conf_key, "")
+        entries.append({
+            "label":    label,
+            "unit":     unit,
+            "schedule": schedule if schedule else "(disabled)",
+            "enabled":  bool(schedule),
+            "source":   "fsbackup.conf",
+        })
+
+    # Fixed timers — schedules defined in systemd unit files
+    for label, unit, schedule in [
+        ("Doctor — class1",    "fsbackup-doctor@class1",      "*-*-* 02:05"),
+        ("Doctor — class2",    "fsbackup-doctor@class2",      "*-*-* 02:05"),
+        ("Doctor — class3",    "fsbackup-doctor@class3",      "*-*-* 02:05"),
+        ("S3 export",          "fsbackup-s3-export",          "*-*-* 04:30"),
+        ("Retention (prune)",  "fsbackup-retention",          "*-*-* 06:00"),
+        ("ZFS pool scrub",     "fsbackup-scrub",              "*-*-05 03:00"),
+        ("Logrotate metric",   "fsbackup-logrotate-metric",   "daily"),
+    ]:
+        entries.append({
+            "label":    label,
+            "unit":     unit,
+            "schedule": schedule,
+            "enabled":  True,
+            "source":   "timer unit",
+        })
+
     return entries
 
 
@@ -923,7 +1024,8 @@ async def configuration_page(request: Request, tab: str = "hosts"):
     primary_disk["fmt_free"]  = _fmt_bytes(primary_disk["free"])
     primary_disk["fmt_total"] = _fmt_bytes(primary_disk["total"])
 
-    crontab = _load_crontab()
+    schedule = _load_schedule()
+    s3_stats = _s3_bucket_stats() if tab == "volumes" else None
 
     return _template_response("configuration.html", {
         "request":        request,
@@ -932,8 +1034,10 @@ async def configuration_page(request: Request, tab: str = "hosts"):
         "targets":        targets,
         "target_volumes": target_volumes,
         "primary_disk":   primary_disk,
-        "crontab":        crontab,
+        "schedule":       schedule,
+        "s3_stats":       s3_stats,
         "snapshot_root":  str(SNAPSHOT_ROOT),
+        "s3_bucket":      S3_BUCKET,
     })
 
 
@@ -980,12 +1084,12 @@ async def api_crontab_schedule(
         except Exception as e:
             error = str(e)
 
-    crontab = _load_crontab()
+    schedule = _load_schedule()
     return _template_response("partials/crontab_table.html", {
-        "request": request,
-        "crontab": crontab,
-        "saved":   saved,
-        "error":   error,
+        "request":  request,
+        "schedule": schedule,
+        "saved":    saved,
+        "error":    error,
     })
 
 

--- a/web/templates/configuration.html
+++ b/web/templates/configuration.html
@@ -34,10 +34,10 @@
     </div>
     {% if hosts %}
     <div class="overflow-x-auto">
-    <table class="w-full text-sm min-w-max">
+    <table class="w-full text-sm min-w-[400px]">
       <thead>
         <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
-          <th class="px-5 py-3 font-medium">Hostname</th>
+          <th class="px-5 py-3 font-medium whitespace-nowrap">Hostname</th>
           <th class="px-5 py-3 font-medium">Targets</th>
         </tr>
       </thead>
@@ -50,8 +50,14 @@
           {% endfor %}
         {% endfor %}
         <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
-          <td class="px-5 py-3 font-mono text-sm text-zinc-900 dark:text-white">{{ host }}</td>
-          <td class="px-5 py-3 text-xs text-zinc-500 dark:text-zinc-400">{{ host_targets | join(", ") }}</td>
+          <td class="px-5 py-3 font-mono text-sm text-zinc-900 dark:text-white whitespace-nowrap">{{ host }}</td>
+          <td class="px-5 py-3">
+            <div class="flex flex-wrap gap-1">
+              {% for tid in host_targets %}
+              <span class="inline-block font-mono text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 px-1.5 py-0.5 rounded">{{ tid }}</span>
+              {% endfor %}
+            </div>
+          </td>
         </tr>
         {% endfor %}
       </tbody>
@@ -111,7 +117,7 @@
           <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
             <td class="px-4 py-2.5 font-medium text-zinc-900 dark:text-white">{{ target.id }}</td>
             <td class="px-4 py-2.5 text-zinc-600 dark:text-zinc-300 font-mono text-xs">{{ target.host }}</td>
-            <td class="px-4 py-2.5 text-zinc-600 dark:text-zinc-300 font-mono text-xs">{{ target.source }}</td>
+            <td class="px-4 py-2.5 text-zinc-600 dark:text-zinc-300 font-mono text-xs break-all max-w-[200px]">{{ target.source }}</td>
             <td class="px-4 py-2.5 text-xs text-zinc-400 font-mono max-w-xs truncate">
               {{ target.rsync_opts if target.rsync_opts is defined else '—' }}
             </td>
@@ -168,89 +174,20 @@
 
 <!-- ============================================================ SCHEDULE -->
 {% elif tab == "schedule" %}
-<div class="mb-4">
-  <p class="text-sm text-zinc-500">Jobs defined in <code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded text-xs">/etc/fsbackup/fsbackup.crontab</code> — read by supercronic (hot-reloads on file change). All times UTC.</p>
+<div class="mb-4 space-y-1">
+  <p class="text-sm text-zinc-500">SystemD timer schedule for all fsbackup jobs.</p>
+  <p class="text-xs text-zinc-400">Runner schedules (<code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded">CLASS*_SCHEDULE</code>) are set in <code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded">/etc/fsbackup/fsbackup.conf</code>. After editing, apply with: <code class="font-mono bg-zinc-100 dark:bg-zinc-800 px-1 rounded">sudo fs-schedule-apply.sh</code></p>
 </div>
 
-{% if crontab %}
-<div id="crontab-table">
+<div id="schedule-table">
   {% include "partials/crontab_table.html" %}
 </div>
-{% else %}
-<div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-8 text-center text-zinc-400 text-sm shadow-sm">
-  Could not read crontab — check that the file exists at <code class="font-mono">/etc/fsbackup/fsbackup.crontab</code>.
-</div>
-{% endif %}
-
-<!-- Cron edit modal -->
-<div id="cron-modal"
-     class="fixed inset-0 z-50 hidden items-center justify-center bg-black/70 backdrop-blur-sm p-4"
-     onclick="if(event.target===this) closeCronModal()">
-  <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl shadow-2xl w-full max-w-md p-6">
-    <div class="flex items-center justify-between mb-4">
-      <h3 class="text-sm font-semibold text-zinc-900 dark:text-white">Edit Schedule</h3>
-      <button onclick="closeCronModal()" class="text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 text-xl leading-none">&times;</button>
-    </div>
-    <p id="cron-modal-label" class="text-xs text-zinc-500 mb-4"></p>
-    <form id="cron-modal-form"
-          hx-post="/api/config/crontab/schedule"
-          hx-target="#crontab-table"
-          hx-swap="innerHTML"
-          hx-on:htmx:after-request="closeCronModal()">
-      <input type="hidden" id="cron-command" name="command" value="">
-      <div class="mb-4">
-        <label class="block text-xs font-medium text-zinc-700 dark:text-zinc-300 mb-1">Cron expression</label>
-        <input type="text" id="cron-schedule" name="schedule"
-               class="w-full font-mono text-sm bg-zinc-50 dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-brand-500"
-               placeholder="minute hour day month weekday"
-               autocomplete="off" spellcheck="false">
-        <p class="text-xs text-zinc-400 mt-1.5">
-          5 fields: minute hour day-of-month month day-of-week —
-          <a id="cron-guru-link" href="https://crontab.guru/" target="_blank" rel="noopener"
-             class="text-brand-600 dark:text-brand-400 hover:underline">crontab.guru ↗</a>
-        </p>
-      </div>
-      <div class="flex justify-end gap-2">
-        <button type="button" onclick="closeCronModal()"
-                class="px-3 py-1.5 text-xs font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors">
-          Cancel
-        </button>
-        <button type="submit"
-                class="px-3 py-1.5 text-xs font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors">
-          Save
-        </button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<script>
-function openCronModal(label, command, schedule) {
-  document.getElementById('cron-modal-label').textContent = label;
-  document.getElementById('cron-command').value = command;
-  document.getElementById('cron-schedule').value = schedule;
-  document.getElementById('cron-guru-link').href =
-    'https://crontab.guru/#' + encodeURIComponent(schedule).replace(/%20/g, '_');
-  document.getElementById('cron-modal').classList.remove('hidden');
-  document.getElementById('cron-modal').classList.add('flex');
-  setTimeout(() => document.getElementById('cron-schedule').focus(), 50);
-}
-function closeCronModal() {
-  document.getElementById('cron-modal').classList.add('hidden');
-  document.getElementById('cron-modal').classList.remove('flex');
-}
-document.addEventListener('click', function(e) {
-  const btn = e.target.closest('.cron-edit-btn');
-  if (btn) openCronModal(btn.dataset.label, btn.dataset.command, btn.dataset.schedule);
-});
-document.addEventListener('keydown', e => { if (e.key === 'Escape') closeCronModal(); });
-</script>
 
 <!-- ============================================================= VOLUMES -->
 {% elif tab == "volumes" %}
 <div class="space-y-6">
 
-  <!-- Volume status card -->
+  <!-- Volume status cards -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm">
       <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">ZFS pool — {{ snapshot_root }}</p>
@@ -269,6 +206,23 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape') closeCronMod
         <span>{{ primary_disk.pct_used }}% used</span>
         <span>{{ primary_disk.fmt_free }} free</span>
       </div>
+      {% endif %}
+    </div>
+
+    <!-- S3 bucket usage -->
+    <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm">
+      <p class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3">S3 — {{ s3_bucket }}</p>
+      {% if s3_stats %}
+      <div class="flex items-end justify-between mb-2">
+        <span class="text-2xl font-bold text-zinc-900 dark:text-white">{{ s3_stats.fmt_size }}</span>
+        <span class="text-xs text-zinc-400">{{ s3_stats.count }} object{% if s3_stats.count != 1 %}s{% endif %}</span>
+      </div>
+      <p class="text-xs text-zinc-400 mt-2">Encrypted <code class="font-mono">tar.zst.age</code> archives — weekly + monthly snapshots for class1 and class2.</p>
+      <a href="/s3" class="inline-block mt-3 text-xs text-brand-600 dark:text-brand-400 hover:underline">Browse bucket &rarr;</a>
+      {% else %}
+      <p class="text-sm text-zinc-400">No data — bucket may be empty or unreachable.</p>
+      <p class="text-xs text-zinc-300 dark:text-zinc-600 mt-1">Bucket: <span class="font-mono">{{ s3_bucket }}</span></p>
+      <a href="/s3" class="inline-block mt-3 text-xs text-brand-600 dark:text-brand-400 hover:underline">Browse bucket &rarr;</a>
       {% endif %}
     </div>
   </div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -37,6 +37,60 @@
   {% endfor %}
 </div>
 
+<!-- S3 export status -->
+<div class="mb-8">
+  <h2 class="text-sm font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-3">S3 Offsite</h2>
+  {% if s3_status %}
+  <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm">
+    <div class="flex items-center justify-between mb-4">
+      <span class="text-sm font-semibold text-zinc-700 dark:text-zinc-300">S3 Export</span>
+      {% if s3_status.status == "ok" %}
+        <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800 px-2.5 py-1 rounded-full">
+          <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 dark:bg-emerald-400"></span> OK
+        </span>
+      {% else %}
+        <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-50 dark:bg-red-900/40 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800 px-2.5 py-1 rounded-full">
+          <span class="w-1.5 h-1.5 rounded-full bg-red-500 dark:bg-red-400"></span> Error
+        </span>
+      {% endif %}
+    </div>
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+      <div>
+        <p class="text-xs text-zinc-400 mb-0.5">Last run</p>
+        <p class="text-sm font-mono font-medium text-zinc-800 dark:text-zinc-200" title="{{ s3_status.last_run_fmt }}">{{ s3_status.last_run }}</p>
+      </div>
+      <div>
+        <p class="text-xs text-zinc-400 mb-0.5">Uploaded</p>
+        <p class="text-sm font-mono font-medium text-zinc-800 dark:text-zinc-200">{{ s3_status.uploaded }}</p>
+      </div>
+      <div>
+        <p class="text-xs text-zinc-400 mb-0.5">Skipped</p>
+        <p class="text-sm font-mono font-medium text-zinc-800 dark:text-zinc-200">{{ s3_status.skipped }}</p>
+      </div>
+      <div>
+        <p class="text-xs text-zinc-400 mb-0.5">Failed</p>
+        <p class="text-sm font-mono font-medium {% if s3_status.failed > 0 %}text-red-600 dark:text-red-400{% else %}text-zinc-800 dark:text-zinc-200{% endif %}">{{ s3_status.failed }}</p>
+      </div>
+    </div>
+    <div class="flex items-center gap-6 text-xs text-zinc-400">
+      <span>Bytes this run: <span class="text-zinc-600 dark:text-zinc-300 font-mono">{{ s3_status.bytes }}</span></span>
+      <span>Duration: <span class="text-zinc-600 dark:text-zinc-300 font-mono">{{ s3_status.duration }}</span></span>
+      <a href="/s3" class="ml-auto text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300">Browse bucket &rarr;</a>
+    </div>
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-5 shadow-sm flex items-center justify-between">
+    <div>
+      <p class="text-sm font-semibold text-zinc-700 dark:text-zinc-300">S3 Export</p>
+      <p class="text-xs text-zinc-400 mt-1">No metrics yet — export has not run or prom file is missing</p>
+    </div>
+    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-zinc-100 dark:bg-zinc-800 text-zinc-500 border border-zinc-200 dark:border-zinc-700 px-2.5 py-1 rounded-full">
+      <span class="w-1.5 h-1.5 rounded-full bg-zinc-400"></span> No data
+    </span>
+  </div>
+  {% endif %}
+</div>
+
 <!-- Quick links -->
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
   {% set links = [

--- a/web/templates/logs.html
+++ b/web/templates/logs.html
@@ -70,31 +70,33 @@
 
 {% if metrics %}
 <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden shadow-sm">
-  <table class="w-full text-sm">
-    <thead>
-      <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
-        <th class="px-5 py-3 font-medium">Metric</th>
-        <th class="px-5 py-3 font-medium">Labels</th>
-        <th class="px-5 py-3 font-medium text-right">Value</th>
-      </tr>
-    </thead>
-    <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
-      {% set ns = namespace(prev_file="") %}
-      {% for row in metrics %}
-        {% if row.file != ns.prev_file %}
-        <tr class="bg-zinc-50 dark:bg-zinc-800/30">
-          <td colspan="3" class="px-5 py-1.5 text-xs font-mono text-zinc-400">{{ row.file }}</td>
+  <div class="overflow-x-auto">
+    <table class="w-full min-w-[640px] text-sm">
+      <thead>
+        <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
+          <th class="px-5 py-3 font-medium whitespace-nowrap">Metric</th>
+          <th class="px-5 py-3 font-medium">Labels</th>
+          <th class="px-5 py-3 font-medium text-right whitespace-nowrap">Value</th>
         </tr>
-        {% set ns.prev_file = row.file %}
-        {% endif %}
-        <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
-          <td class="px-5 py-2 font-mono text-xs text-zinc-700 dark:text-zinc-300" title="{{ row.help }}">{{ row.metric }}</td>
-          <td class="px-5 py-2 font-mono text-xs text-zinc-500">{{ row.labels or "—" }}</td>
-          <td class="px-5 py-2 font-mono text-xs text-zinc-900 dark:text-zinc-100 text-right">{{ row.value }}</td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+        {% set ns = namespace(prev_file="") %}
+        {% for row in metrics %}
+          {% if row.file != ns.prev_file %}
+          <tr class="bg-zinc-50 dark:bg-zinc-800/30">
+            <td colspan="3" class="px-5 py-1.5 text-xs font-mono text-zinc-400">{{ row.file }}</td>
+          </tr>
+          {% set ns.prev_file = row.file %}
+          {% endif %}
+          <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
+            <td class="px-5 py-2 font-mono text-xs text-zinc-700 dark:text-zinc-300 whitespace-nowrap" title="{{ row.help }}">{{ row.metric }}</td>
+            <td class="px-5 py-2 font-mono text-xs text-zinc-500 break-all max-w-xs">{{ row.labels or "—" }}</td>
+            <td class="px-5 py-2 font-mono text-xs text-zinc-900 dark:text-zinc-100 text-right whitespace-nowrap">{{ row.value }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
 {% else %}
 <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-8 text-center text-zinc-400 text-sm shadow-sm">

--- a/web/templates/partials/crontab_table.html
+++ b/web/templates/partials/crontab_table.html
@@ -4,40 +4,42 @@
 </div>
 {% elif saved %}
 <div class="mb-3 bg-green-50 dark:bg-green-950/40 border border-green-200 dark:border-green-800 rounded-lg px-4 py-2.5 text-sm text-green-700 dark:text-green-400">
-  Schedule saved — supercronic will pick up the change automatically.
+  Schedule saved — run <code class="font-mono">sudo fs-schedule-apply.sh</code> to apply.
 </div>
 {% endif %}
 
 <div class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden shadow-sm">
-  <table class="w-full text-sm">
-    <thead>
-      <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
-        <th class="px-5 py-3 font-medium">Job</th>
-        <th class="px-5 py-3 font-medium">Schedule</th>
-        <th class="px-5 py-3 font-medium hidden xl:table-cell">Command</th>
-        <th class="px-5 py-3 font-medium w-10"></th>
-      </tr>
-    </thead>
-    <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
-      {% for entry in crontab %}
-      <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors">
-        <td class="px-5 py-3 text-zinc-900 dark:text-zinc-100 font-medium">{{ entry.label }}</td>
-        <td class="px-5 py-3 font-mono text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap">{{ entry.schedule }}</td>
-        <td class="px-5 py-3 font-mono text-xs text-zinc-400 dark:text-zinc-500 hidden xl:table-cell max-w-sm truncate" title="{{ entry.command }}">{{ entry.command }}</td>
-        <td class="px-5 py-3 text-right">
-          <button type="button"
-                  class="cron-edit-btn text-xs text-zinc-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors"
-                  data-label="{{ entry.label | e }}"
-                  data-command="{{ entry.command | e }}"
-                  data-schedule="{{ entry.schedule | e }}"
-                  title="Edit schedule">
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-            </svg>
-          </button>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm min-w-[500px]">
+      <thead>
+        <tr class="text-left text-xs text-zinc-500 uppercase tracking-wider bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
+          <th class="px-5 py-3 font-medium">Job</th>
+          <th class="px-5 py-3 font-medium">OnCalendar</th>
+          <th class="px-5 py-3 font-medium hidden xl:table-cell">Timer unit</th>
+          <th class="px-5 py-3 font-medium hidden sm:table-cell w-20 text-right">Source</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+        {% for entry in schedule %}
+        <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors {% if not entry.enabled %}opacity-50{% endif %}">
+          <td class="px-5 py-3 text-zinc-900 dark:text-zinc-100 font-medium">
+            {{ entry.label }}
+            {% if not entry.enabled %}
+            <span class="ml-1.5 text-xs font-normal text-zinc-400">(disabled)</span>
+            {% endif %}
+          </td>
+          <td class="px-5 py-3 font-mono text-xs {% if entry.enabled %}text-zinc-600 dark:text-zinc-300{% else %}text-zinc-400{% endif %} whitespace-nowrap">{{ entry.schedule }}</td>
+          <td class="px-5 py-3 font-mono text-xs text-zinc-400 dark:text-zinc-500 hidden xl:table-cell">{{ entry.unit }}</td>
+          <td class="px-5 py-3 hidden sm:table-cell text-right">
+            {% if entry.source == "fsbackup.conf" %}
+            <span class="text-xs text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">conf</span>
+            {% else %}
+            <span class="text-xs text-zinc-300 dark:text-zinc-600">unit</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
## Summary

- **S3 export live**: `age.pub` was missing; now provisioned. Added `trap` to clean up `PROM_TMP` on early exit, and surface `zfs list` errors to the log instead of silencing them.
- **Dashboard**: New S3 export status card showing last run time, uploaded/skipped/failed counts, bytes, and duration. Hardens class-status prom reads with try/except and uses `PROM_DIR` constant consistently.
- **Logs page**: Metrics table now has horizontal scroll wrapper + `break-all` on labels column + `whitespace-nowrap` on metric/value columns.
- **Configuration — Hosts tab**: Targets column now wraps as inline badge chips instead of one long comma-joined line.
- **Configuration — Targets tab**: Source path column gets `break-all max-w-[200px]`.
- **Configuration — Schedule tab**: Replaced broken crontab-based view (file never existed in v2.0) with systemd timer schedule sourced from `fsbackup.conf` + static timer unit values. Disabled entries show at reduced opacity.
- **Configuration — Volumes tab**: Added S3 bucket usage card (object count + total size via `list_objects_v2`).
- **reference.md**: Snapshot paths updated to v2.0 ZFS layout; offsite S3 section rewritten as live (not planned); timer schedule table reflects actual v2.0 units and times; mirror/promote marked as not in v2.0; retention time corrected (03:00 → 06:00); S3 Prometheus metrics added to reference table.

## Test plan

- [x] Verify S3 export service starts and uploads (backfill all missed weekly/monthly snapshots)
- [x] Dashboard loads with S3 status card (shows "No data" before first run, live stats after)
- [x] Logs → Metrics table scrolls horizontally on narrow viewports; labels wrap within column
- [x] Configuration → Hosts: targets column shows multi-line badges for hosts with many targets
- [x] Configuration → Targets: source paths wrap within column
- [x] Configuration → Schedule: shows all 14 timer entries; disabled entries (class2 monthly) appear dimmed
- [x] Configuration → Volumes: S3 card shows bucket size and object count

🤖 Generated with [Claude Code](https://claude.com/claude-code)