### PR TITLE
fix(provision): chown new dataset mountpoints to fsbackup

### DIFF
--- a/bin/fs-provision.sh
+++ b/bin/fs-provision.sh
@@ -84,6 +84,11 @@ while IFS= read -r entry; do
       CREATED=$((CREATED + 1))
     else
       if zfs create -p "$dataset"; then
+        # zfs create leaves the mountpoint root-owned; the runner rsyncs into
+        # it as the fsbackup user and fails with EACCES unless we chown it
+        mnt="$(zfs get -H -o value mountpoint "$dataset")"
+        chown fsbackup:fsbackup "$mnt" \
+          || echo "  WARN  could not chown $mnt to fsbackup — runner will fail until fixed"
         printf "  %-8s %-12s %s\n" "CREATED" "[$cls]" "$dataset"
         CREATED=$((CREATED + 1))
       else


### PR DESCRIPTION
## Problem

`fs-provision.sh` creates datasets with `zfs create -p` running as root, which leaves the new mountpoint owned `root:root`. The runner writes into it as the `fsbackup` user, so the first backup of any freshly provisioned target fails:

```
rsync: [generator] recv_generator: mkdir "/backup/snapshots/class1/ian.files/affinity" failed: Permission denied (13)
```

Hit in production 2026-08-15 with the new `ian.files` / `jim.files` targets; the pre-existing datasets only worked because they were chowned manually during initial setup.

## Fix

After a successful `zfs create`, resolve the mountpoint and `chown fsbackup:fsbackup` it. A chown failure prints a WARN (per-iteration error handling, no `set -e`) instead of aborting the provisioning loop.

The two live datasets were already fixed by hand on `fs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)