### PR TITLE
feat: auto-provision datasets for new targets from the runner

### DIFF
--- a/bin/fs-doctor.sh
+++ b/bin/fs-doctor.sh
@@ -59,6 +59,7 @@ SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=5)
 PASS=0
 FAIL=0
 WARN=0
+MISSING_DATASETS=0
 
 echo
 echo "fsbackup doctor"
@@ -79,6 +80,13 @@ for t in "${TARGETS[@]}"; do
   if [[ -z "$id" || -z "$host" || -z "$src" ]]; then
     printf "%-28s %-6s %s\n" "${id:-<unknown>}" "WARN" "invalid target entry"
     ((WARN++))
+    continue
+  fi
+
+  if [[ ! -d "${PRIMARY_SNAPSHOT_ROOT}/${CLASS}/${id}" ]]; then
+    printf "%-28s %-6s %s\n" "$id" "WARN" "dataset not provisioned (runner will auto-provision)"
+    ((WARN++))
+    ((MISSING_DATASETS++))
     continue
   fi
 
@@ -151,6 +159,9 @@ cat >"$tmp" <<EOF
 # HELP fsbackup_doctor_duration_seconds Duration of fsbackup doctor run
 # TYPE fsbackup_doctor_duration_seconds gauge
 fsbackup_doctor_duration_seconds{class="$CLASS"} ${DURATION}
+# HELP fsbackup_doctor_missing_datasets Targets in targets.yml with no provisioned dataset
+# TYPE fsbackup_doctor_missing_datasets gauge
+fsbackup_doctor_missing_datasets{class="$CLASS"} ${MISSING_DATASETS}
 EOF
 chgrp nodeexp_txt "$tmp" 2>/dev/null || true
 chmod 0644 "$tmp"

--- a/bin/fs-install.sh
+++ b/bin/fs-install.sh
@@ -178,6 +178,20 @@ else
     warn "sudoers syntax check failed — removing ${SUDOERS_FILE}"
     rm -f "$SUDOERS_FILE"
 fi
+
+# sudoers drop-in: allow fsbackup to run fs-provision.sh as root so the runner
+# can auto-provision datasets for newly added targets (dataset creation needs
+# root: Linux ZFS does not honor delegated mounts via zfs allow).
+SUDOERS_PROVISION_FILE="/etc/sudoers.d/fsbackup-provision"
+SUDOERS_PROVISION_LINE="${FSBACKUP_USER} ALL=(root) NOPASSWD: ${INSTALL_DIR}/bin/fs-provision.sh"
+echo "$SUDOERS_PROVISION_LINE" > "$SUDOERS_PROVISION_FILE"
+chmod 0440 "$SUDOERS_PROVISION_FILE"
+if visudo -c -f "$SUDOERS_PROVISION_FILE" &>/dev/null; then
+    ok "sudoers drop-in written: ${SUDOERS_PROVISION_FILE}"
+else
+    warn "sudoers syntax check failed — removing ${SUDOERS_PROVISION_FILE}"
+    rm -f "$SUDOERS_PROVISION_FILE"
+fi
 echo
 
 # ---------------------------------------------------------------------------

--- a/bin/fs-runner.sh
+++ b/bin/fs-runner.sh
@@ -112,6 +112,29 @@ echo "  Snap suffix:   @${SNAP_SUFFIX}"
 echo
 
 # -----------------------------------------------------------------------------
+# Auto-provision missing datasets
+# -----------------------------------------------------------------------------
+# The runner runs as fsbackup, which cannot create datasets itself — Linux ZFS
+# does not honor delegated mounts via `zfs allow` — so provisioning goes through
+# a sudoers drop-in scoped to fs-provision.sh (written by fs-install.sh step 5).
+
+PROVISION_NEEDED=0
+for t in "${TARGETS[@]}"; do
+  id="$(jq -r '.id' <<<"$t")"
+  [[ -d "${SNAPSHOT_ROOT}/${CLASS}/${id}" ]] || { PROVISION_NEEDED=1; break; }
+done
+
+if [[ "$PROVISION_NEEDED" -eq 1 ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "provision" "dry-run: missing dataset(s) detected — would run fs-provision.sh"
+  elif sudo -n /opt/fsbackup/bin/fs-provision.sh >>"$LOG_FILE" 2>&1; then
+    log "provision" "missing dataset(s) detected — fs-provision.sh completed"
+  else
+    log "provision" "WARN: fs-provision.sh failed — missing datasets will be skipped (check sudoers drop-in)"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # Load existing failure counters and last_success values
 # -----------------------------------------------------------------------------
 

--- a/docs/adding-hosts-and-targets.md
+++ b/docs/adding-hosts-and-targets.md
@@ -75,6 +75,15 @@ code 23 and `Permission denied` errors in the journal.
 sudo -u fsbackup /opt/fsbackup/bin/fs-doctor.sh --class class2
 ```
 
+The ZFS dataset for a new target is created automatically at the start of the
+runner's next scheduled run (`fs-provision.sh` via a sudoers drop-in), and the
+doctor flags any target whose dataset does not exist yet. To provision
+immediately instead of waiting for the next run:
+
+```bash
+sudo /opt/fsbackup/bin/fs-provision.sh
+```
+
 ---
 
 ## Adding a new remote host


### PR DESCRIPTION
## Problem

Adding a target to `targets.yml` requires a manual `sudo fs-provision.sh` before the next run. Forgetting it means the first backup fails overnight instead of at edit time (seen 2026-08-15 with `ian.files`/`jim.files`). The doctor can't catch class1 either — its 02:05 timer fires *after* the class1 daily runner (01:46).

## Changes

**Runner auto-provision** — `fs-runner.sh` scans its class for targets with no dataset before the loop; if any are missing it runs `sudo -n fs-provision.sh` (idempotent, chowns since #77). Dry-run only logs what it would do; a failed provision falls back to the existing per-target WARN+skip.

**Sudoers drop-in** — the runner executes as `fsbackup`, and Linux ZFS doesn't honor delegated mounts via `zfs allow`, so dataset creation needs root. `fs-install.sh` now writes `/etc/sudoers.d/fsbackup-provision` (NOPASSWD, scoped to the installed `fs-provision.sh`), mirroring the existing `fsbackup-zfs-destroy` drop-in.

**Doctor early warning** — per-target WARN when a dataset is missing, plus a new `fsbackup_doctor_missing_datasets{class}` gauge (written to the doctor duration prom file; inherits the known #52 shared-file caveat).

**Docs** — `adding-hosts-and-targets.md` notes auto-provisioning and the immediate manual option.

## Deploy note

Existing installs won't re-run the installer — the sudoers drop-in must be created once by hand on `fs` (same line the installer writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)