### PR TITLE
fix(web): block path traversal in file browser; parse ISO weeks correctly

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -108,9 +108,9 @@ def parse_snapshot_date(tier: str, date_str: str) -> date | None:
         if tier == "daily":
             return datetime.strptime(date_str, "%Y-%m-%d").date()
         elif tier == "weekly":
-            # YYYY-Www  e.g. 2025-W03
+            # ISO week: YYYY-Www  e.g. 2025-W03 (matches `date +%G-W%V` in fs-runner.sh)
             year, week = date_str.split("-W")
-            return datetime.strptime(f"{year}-W{week}-1", "%Y-W%W-%w").date()
+            return date.fromisocalendar(int(year), int(week), 1)
         elif tier == "monthly":
             return datetime.strptime(date_str, "%Y-%m").date()
         elif tier == "annual":
@@ -497,11 +497,11 @@ async def browse_page(request: Request, path: str = ""):
     browse_path = None
 
     if path:
-        browse_path = Path(path)
-        # Safety: must be under SNAPSHOT_ROOT
-        try:
-            browse_path.relative_to(SNAPSHOT_ROOT)
-        except ValueError:
+        # Safety: resolve symlinks/.. first, then require the real path to be
+        # under SNAPSHOT_ROOT (a bare relative_to() check is lexical and lets
+        # ../ escape the root).
+        browse_path = Path(path).resolve()
+        if not browse_path.is_relative_to(SNAPSHOT_ROOT):
             error = "Path is outside snapshot root."
             browse_path = None
 
@@ -1206,10 +1206,9 @@ async def api_browse(request: Request, path: str = ""):
     error   = None
 
     if path:
-        browse_path = Path(path)
-        try:
-            browse_path.relative_to(SNAPSHOT_ROOT)
-        except ValueError:
+        # Resolve before the containment check so ../ cannot escape the root.
+        browse_path = Path(path).resolve()
+        if not browse_path.is_relative_to(SNAPSHOT_ROOT):
             error = "Path is outside snapshot root."
             browse_path = None
 


### PR DESCRIPTION
Fixes the two confirmed bugs from the repo audit.

## #79 — Path traversal in the snapshot file browser
`/browse` and `/api/browse` validated containment with `Path.relative_to(SNAPSHOT_ROOT)` on the **unresolved** path. That check is purely lexical, so `?path=/backup/snapshots/class1/../../../etc` passed and the endpoint happily listed `/etc` (names, sizes, mtimes). Now the path is `.resolve()`d first and checked with `is_relative_to()`, the same way `/api/run/restore` already does it.

Verified: `/backup/snapshots/class1/../../../etc` now resolves to `/etc` and is rejected (`under_root=False`); legitimate snapshot paths still pass.

## #80 — Weekly snapshot expiry shown with the wrong date
The runner writes ISO weeks (`date +%G-W%V`, e.g. `@weekly-2026-W15`), but the UI parsed them with `%W` (`"%Y-W%W-%w"`), a different week convention. Result: `2026-W15` displayed as `2026-04-13` instead of the correct `2026-04-06`, and 53-week years raised. Now parsed with `date.fromisocalendar()`.

Verified: `2026-W15 → 2026-04-06`, `2026-W01 → 2025-12-29` (both correct). Display-only fix — ZFS retention is count-based and was never affected.

Closes #79
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
