### PR TITLE
feat(web): trust reverse-proxy forwarded headers (real client IPs for throttle)

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -47,6 +47,17 @@ AUTH_ENABLED=true
 # SESSION_COOKIE_SECURE=false
 
 # ---------------------------------------------------------------------------
+# Reverse proxy
+# ---------------------------------------------------------------------------
+# If the UI is served through a reverse proxy, set this to the proxy's IP(s)
+# (comma-separated, or "*" to trust all — only safe if nothing untrusted can
+# reach the app directly). The app then trusts X-Forwarded-For/Proto from the
+# proxy, so the login throttle sees real client IPs instead of the proxy's.
+# The proxy must forward the original Host header (CSRF check) plus
+# X-Forwarded-For and X-Forwarded-Proto. Pair with SESSION_COOKIE_SECURE=true.
+# PROXY_TRUSTED_IPS=
+
+# ---------------------------------------------------------------------------
 # S3 offsite
 # ---------------------------------------------------------------------------
 S3_BUCKET=fsbackup-snapshots-SUFFIX

--- a/web/README.md
+++ b/web/README.md
@@ -161,10 +161,32 @@ running under systemd, you can use `EnvironmentFile=` in the unit file instead.
 | `AUTH_USERNAME` | *(unset)* | If set, the login username must match this too; empty = any username accepted |
 | `SECRET_KEY` | *(random)* | Session-cookie signing key; set a stable value to keep sessions across restarts |
 | `SESSION_COOKIE_SECURE` | `false` | Mark the session cookie `Secure` when served over HTTPS |
+| `PROXY_TRUSTED_IPS` | *(unset)* | Reverse-proxy IP(s) whose `X-Forwarded-*` headers to trust (comma-separated, or `*`); makes the login throttle see real client IPs |
 
 > `HOST` and `PORT` are read by the `if __name__ == "__main__"` entrypoint in
 > `main.py`. If you start the app via `uvicorn main:app` directly on the command
 > line, pass `--host` and `--port` explicitly or export the variables first.
+
+### Behind a reverse proxy
+
+When the UI is served through a reverse proxy (TLS termination, an internal
+hostname, etc.), set two things in `web/.env`:
+
+```bash
+PROXY_TRUSTED_IPS=10.0.0.5     # the proxy's IP; the app trusts its X-Forwarded-* headers
+SESSION_COOKIE_SECURE=true     # the browser leg is HTTPS
+```
+
+`PROXY_TRUSTED_IPS` makes `request.client.host` the real client IP, so the login
+throttle buckets per client instead of locking out everyone behind the proxy. The
+proxy must forward the original **Host** header (the CSRF check compares it against
+the request's `Origin`), plus `X-Forwarded-For` and `X-Forwarded-Proto`. For nginx:
+
+```nginx
+proxy_set_header Host              $host;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
 
 ---
 

--- a/web/main.py
+++ b/web/main.py
@@ -77,6 +77,10 @@ AUTH_PASSWORD_HASH = os.environ.get("AUTH_PASSWORD_HASH", "")
 AUTH_USERNAME     = os.environ.get("AUTH_USERNAME", "")
 # Mark the session cookie Secure when the UI is served over HTTPS.
 SESSION_COOKIE_SECURE = os.environ.get("SESSION_COOKIE_SECURE", "false").lower() in ("true", "1", "yes")
+# Reverse-proxy support: comma-separated IPs (or "*") whose X-Forwarded-* headers
+# to trust. When set, request.client.host becomes the real client IP — so the
+# login throttle buckets per client rather than per proxy. Empty = direct access.
+PROXY_TRUSTED_IPS = os.environ.get("PROXY_TRUSTED_IPS", "").strip()
 
 # Login throttling — per client IP, in-memory (single-process app).
 LOGIN_MAX_ATTEMPTS = 5     # failures within the window before lockout
@@ -1449,9 +1453,15 @@ async def api_run(request: Request, action: str, cls: str = Form(default="")):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(
-        "main:app",
+    kwargs = dict(
         host=os.environ.get("HOST", "0.0.0.0"),
         port=int(os.environ.get("PORT", "8080")),
         reload=False,
     )
+    # Behind a reverse proxy, trust X-Forwarded-* only from the proxy so
+    # request.client.host / scheme reflect the real client (used by the login
+    # throttle). Without this, every request appears to come from the proxy.
+    if PROXY_TRUSTED_IPS:
+        kwargs["proxy_headers"] = True
+        kwargs["forwarded_allow_ips"] = PROXY_TRUSTED_IPS
+    uvicorn.run("main:app", **kwargs)


### PR DESCRIPTION
Follow-up to the login-hardening work (#90) for deployments behind a reverse proxy — e.g. an internal TLS proxy in front of `fsbackup-web`.

## Problem
Behind a proxy, `request.client.host` is the **proxy's** IP for every request, so the per-IP login throttle from #90 buckets all users together: one person's 5 failed logins would lock out everyone, and an attacker's real IP is invisible.

## Change
- **`PROXY_TRUSTED_IPS`** (new, unset by default): when set, the app starts uvicorn with `proxy_headers=True` and `forwarded_allow_ips=<ips>`, so `request.client.host` and the scheme come from `X-Forwarded-For` / `X-Forwarded-Proto` — i.e. the real client. The throttle then buckets per client. Comma-separated, or `*`.
- Direct-access behavior is unchanged when it's unset.
- Docs: `.env.example` + README config table + a "Behind a reverse proxy" section pairing it with `SESSION_COOKIE_SECURE=true` and the required proxy headers (preserve **Host** for the CSRF check, forward `X-Forwarded-For`/`Proto`), with an nginx snippet.

## Verification
- `python -m py_compile web/main.py` passes.
- Live test with `PROXY_TRUSTED_IPS=127.0.0.1`: a client at `X-Forwarded-For: 1.1.1.1` is locked out after 5 failures, while `2.2.2.2` is unaffected — confirming per-real-client bucketing. Without the fix both would share the proxy's bucket.

## Deploy note (this instance)
`fs` runs behind an internal proxy on `172.30.3.10`, so after merge:
```
# /opt/fsbackup/web/.env
PROXY_TRUSTED_IPS=172.30.3.10
SESSION_COOKIE_SECURE=true
```
then `systemctl restart fsbackup-web`. The proxy already preserves Host (verified: CSRF POSTs succeed through it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
